### PR TITLE
Only support format contexts for search and replace

### DIFF
--- a/hyper_bump_it/_files.py
+++ b/hyper_bump_it/_files.py
@@ -58,10 +58,10 @@ def _planned_change_for(
     replace_pattern: str,
     formatter: TextFormatter,
 ) -> PlannedChange:
-    search_text = formatter.format(search_pattern, FormatContext.current)
+    search_text = formatter.format(search_pattern, FormatContext.search)
     for i, line in enumerate(file.read_text().splitlines()):
         if search_text in line:
-            replace_text = formatter.format(replace_pattern, FormatContext.new)
+            replace_text = formatter.format(replace_pattern, FormatContext.replace)
             return PlannedChange(
                 file,
                 line_index=i,

--- a/hyper_bump_it/_text_formatter/text_formatter.py
+++ b/hyper_bump_it/_text_formatter/text_formatter.py
@@ -2,7 +2,7 @@
 Central place for performing text formatting.
 """
 from datetime import date
-from enum import Enum
+from enum import Enum, auto
 from typing import Optional
 
 from semantic_version import Version
@@ -12,8 +12,8 @@ from hyper_bump_it._text_formatter import keys
 
 
 class FormatContext(Enum):
-    current = 1
-    new = 2
+    search = auto()
+    replace = auto()
 
 
 class TextFormatter:
@@ -35,13 +35,14 @@ class TextFormatter:
         self._today = today or date.today()
 
     def format(
-        self, format_pattern: str, context: FormatContext = FormatContext.current
+        self, format_pattern: str, context: Optional[FormatContext] = None
     ) -> str:
         """
         Perform string formatting on the given pattern.
 
         :param format_pattern: Pattern to be formatted.
-        :param context: Which version should be used for the general keys. Default: current.
+        :param context: What context the format pattern is being evaluated. This controls that
+            values used for the optional general keys. Default: None.
         :return: Result of string formatting.
         :raises FormatError: Format pattern was invalid or attempted to use an invalid key.
         """
@@ -71,10 +72,11 @@ class TextFormatter:
             values[keys.PRERELEASE] = _merge_parts(version.prerelease)
             values[keys.BUILD] = _merge_parts(version.build)
 
-        if context == FormatContext.current:
-            _add_general(self._current_version)
-        else:
-            _add_general(self._new_version)
+        if context is not None:
+            if context == FormatContext.search:
+                _add_general(self._current_version)
+            else:
+                _add_general(self._new_version)
 
         try:
             return format_pattern.format(**values)

--- a/tests/test_text_formatter.py
+++ b/tests/test_text_formatter.py
@@ -53,18 +53,18 @@ def test_format__use_optional_keys_for_version_without_values__empty_string_inse
 @pytest.mark.parametrize(
     ["context", "key", "expected_value"],
     [
-        (FormatContext.current, keys.VERSION, str(sd.SOME_VERSION)),
-        (FormatContext.current, keys.MAJOR, str(sd.SOME_MAJOR)),
-        (FormatContext.current, keys.MINOR, str(sd.SOME_MINOR)),
-        (FormatContext.current, keys.PATCH, str(sd.SOME_PATCH)),
-        (FormatContext.current, keys.PRERELEASE, sd.SOME_PRERELEASE),
-        (FormatContext.current, keys.BUILD, sd.SOME_BUILD),
-        (FormatContext.new, keys.VERSION, str(sd.SOME_OTHER_VERSION)),
-        (FormatContext.new, keys.MAJOR, str(sd.SOME_OTHER_MAJOR)),
-        (FormatContext.new, keys.MINOR, str(sd.SOME_OTHER_MINOR)),
-        (FormatContext.new, keys.PATCH, str(sd.SOME_OTHER_PATCH)),
-        (FormatContext.new, keys.PRERELEASE, sd.SOME_OTHER_PRERELEASE),
-        (FormatContext.new, keys.BUILD, sd.SOME_OTHER_BUILD),
+        (FormatContext.search, keys.VERSION, str(sd.SOME_VERSION)),
+        (FormatContext.search, keys.MAJOR, str(sd.SOME_MAJOR)),
+        (FormatContext.search, keys.MINOR, str(sd.SOME_MINOR)),
+        (FormatContext.search, keys.PATCH, str(sd.SOME_PATCH)),
+        (FormatContext.search, keys.PRERELEASE, sd.SOME_PRERELEASE),
+        (FormatContext.search, keys.BUILD, sd.SOME_BUILD),
+        (FormatContext.replace, keys.VERSION, str(sd.SOME_OTHER_VERSION)),
+        (FormatContext.replace, keys.MAJOR, str(sd.SOME_OTHER_MAJOR)),
+        (FormatContext.replace, keys.MINOR, str(sd.SOME_OTHER_MINOR)),
+        (FormatContext.replace, keys.PATCH, str(sd.SOME_OTHER_PATCH)),
+        (FormatContext.replace, keys.PRERELEASE, sd.SOME_OTHER_PRERELEASE),
+        (FormatContext.replace, keys.BUILD, sd.SOME_OTHER_BUILD),
     ],
 )
 def test_format__specified_context__respective_version(
@@ -77,7 +77,9 @@ def test_format__specified_context__respective_version(
 @pytest.mark.parametrize("key", ALL_KEYS)
 def test_format__each_key__valid_result(key: str):
     # ensure that each key is usable & we didn't forget to add an explicit test case
-    result = TEXT_FORMATTER.format(f"--{{{getattr(keys, key)}}}--")
+    result = TEXT_FORMATTER.format(
+        f"--{{{getattr(keys, key)}}}--", context=FormatContext.search
+    )
     assert re.match("^--.+-$", result)
 
 


### PR DESCRIPTION
This is the only time when a pattern might be used for two different things. In other cases it is better to be explicit.