### PR TITLE
Don't attempt to operate on a repo with no commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Fixed
+
+* Crash when executing against a repository without any commits. A clear error message is displayed
+    instead.
+
 ## [0.1.0] - 2022-12-16
 
 First functional release

--- a/hyper_bump_it/_error.py
+++ b/hyper_bump_it/_error.py
@@ -194,6 +194,15 @@ class NoRepositoryError(GitError):
         return f"The project root '{_rich_path(self.project_root)}' is not a git repository"
 
 
+class EmptyRepositoryError(GitError):
+    def __init__(self, project_root: Path) -> None:
+        self.project_root = project_root
+        super().__init__(f"The repository at '{self.project_root}' has no commits")
+
+    def __rich__(self) -> str:
+        return f"The repository at '{_rich_path(self.project_root)}' has no commits"
+
+
 class DirtyRepositoryError(GitError):
     def __init__(self, project_root: Path) -> None:
         self.project_root = project_root

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -35,6 +35,7 @@ SOME_SUB_TABLES = ("some-name", "some-sub-name")
             Path(sd.SOME_DIRECTORY_NAME), sd.SOME_SEARCH_FORMAT_PATTERN
         ),
         error.NoRepositoryError(Path(sd.SOME_DIRECTORY_NAME)),
+        error.EmptyRepositoryError(Path(sd.SOME_DIRECTORY_NAME)),
         error.DirtyRepositoryError(Path(sd.SOME_DIRECTORY_NAME)),
         error.DetachedRepositoryError(Path(sd.SOME_DIRECTORY_NAME)),
         error.MissingRemoteError(sd.SOME_REMOTE, Path(sd.SOME_DIRECTORY_NAME)),

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+from git import Repo
 
 from hyper_bump_it import _git as git
 from hyper_bump_it._config import GitAction, GitActions
@@ -8,6 +9,7 @@ from hyper_bump_it._error import (
     AlreadyExistsError,
     DetachedRepositoryError,
     DirtyRepositoryError,
+    EmptyRepositoryError,
     MissingRemoteError,
     NoRepositoryError,
 )
@@ -72,6 +74,21 @@ def test_get_vetted_repo__existing_branch__error(tmp_path: Path):
     with pytest.raises(AlreadyExistsError, match="branch"):
         git.get_vetted_repo(
             repo.path,
+            sd.some_git_operations_info(
+                actions=sd.some_git_actions(
+                    commit=GitAction.Create, branch=GitAction.Create
+                )
+            ),
+        )
+
+
+def test_get_vetted_repo__no_commits_create_branch_plan__error(tmp_path: Path):
+    repo = Repo.init(tmp_path)
+    print(repo.heads)
+
+    with pytest.raises(EmptyRepositoryError):
+        git.get_vetted_repo(
+            tmp_path,
             sd.some_git_operations_info(
                 actions=sd.some_git_actions(
                     commit=GitAction.Create, branch=GitAction.Create


### PR DESCRIPTION
While just creating a commit from this state can operate successfully, it doesn't make much sense for the first commit to a repository be from `hyper-bump-it` changing the version number. Therefore, operating from this state is completely disallowed.

Fixes #54 