### PR TITLE
Allow for skipping confirmation prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## Fixed
+### Added
+
+* Controls related to the interactive confirmation prompt
+    * `show_confirm_prompt` in configuration file can explicitly enable (default) or disable the
+        prompt.
+    * `-y` & `--yes` as command line options to disable the prompt.
+    * `--interactive` as command line options to explicitly enable the prompt.
+    * `-n` & `--no` command line options as aliases for `--dry-run`.
+
+### Fixed
 
 * Crash when executing against a repository without any commits. A clear error message is displayed
     instead.

--- a/docs/usage-guide/configuration.md
+++ b/docs/usage-guide/configuration.md
@@ -39,6 +39,40 @@ reasonable defaults, so the following is a functional configuration.
     file_glob = "*.txt"
     ```
 
+### Top Level Table
+
+There are a few fields that can be specified as part of the top level table.
+
+The most common is the `current_version` field, which contains the current version. How this is
+used and the alternative option are discussed in a [latter section][current-version-keystone].
+
+The other optional field is `show_confirm_prompt`. If this field is not specified (default) or set
+to `true`, `hyper-bump-it` will prompt the user to confirm the changes described in the execution
+plan before performing the actions. When set to `false`, the prompt will **not** be displayed.
+Instead, the actions will be immediately performed.
+
+The following is an example configuration which disables the confirmation prompt.
+
+=== "hyper-bump-it.toml"
+    ```toml
+    [hyper-bump-it]
+    current_version = "1.2.3"
+    show_confirm_prompt = false
+
+    [[hyper-bump-it.files]]
+    file_glob = "*.txt"
+    ```
+
+=== "pyproject.toml"
+    ```toml
+    [tool.hyper-bump-it]
+    current_version = "1.2.3"
+    show_confirm_prompt = false
+
+    [[tool.hyper-bump-it.files]]
+    file_glob = "*.txt"
+    ```
+
 ### Files
 
 The most important part of the configuration is the list of file definitions. This is how
@@ -61,7 +95,7 @@ If `search_format_pattern` is not specified, the default value of `"{version}"` 
 `replace_format_pattern` is not specified, the value of `search_format_pattern` is used.
 
 There is an additional optional field named `keystone`, this is discussed in a
-[latter section][keystone].
+[latter section][current-version-keystone].
 
 The following is an example configuration which has two file definitions that both customize the
 `search_format_pattern`.
@@ -210,7 +244,7 @@ With this functionality enabled, there are a few restrictions:
 [toml]: https://toml.io/
 [glob]: https://docs.python.org/3/library/glob.html
 [format-patterns]: format-patterns.md
-[keystone]: #current-version
+[current-version-keystone]: #current-version
 [git-integration]: git-integration.md
 [git-actions]: git-integration.md#actions
 [supported-keys]: format-patterns.md#supported-keys

--- a/hyper_bump_it/_cli.py
+++ b/hyper_bump_it/_cli.py
@@ -40,7 +40,18 @@ PROJECT_ROOT = typer.Option(
 )
 DRY_RUN = typer.Option(
     False,
-    help="Only display the operations that would be performed",
+    "--no",
+    "-n",
+    "--dry-run/--no-dry-run",
+    help="Answer no to the confirmation prompt. "
+    "Only displaying the operations that would be performed",
+    show_default=False,
+)
+SKIP_CONFIRM_PROMPT = typer.Option(
+    None,
+    "--yes/--interactive",
+    "-y",
+    help="Answer yes to the confirmation prompt and run non-interactively",
     show_default=False,
 )
 CURRENT_VERSION = typer.Option(
@@ -101,6 +112,7 @@ def to(
     config_file: Optional[Path] = CONFIG_FILE,
     project_root: Path = PROJECT_ROOT,
     dry_run: bool = DRY_RUN,
+    skip_confirm_prompt: Optional[bool] = SKIP_CONFIRM_PROMPT,
     current_version: Optional[str] = CURRENT_VERSION,
     commit: Optional[GitAction] = COMMIT,
     branch: Optional[GitAction] = BRANCH,
@@ -123,6 +135,7 @@ def to(
                 config_file=config_file,
                 project_root=project_root,
                 dry_run=dry_run,
+                skip_confirm_prompt=skip_confirm_prompt,
                 current_version=current_version_parsed,
                 commit=commit,
                 branch=branch,
@@ -145,6 +158,7 @@ def by(
     config_file: Optional[Path] = CONFIG_FILE,
     project_root: Path = PROJECT_ROOT,
     dry_run: bool = DRY_RUN,
+    skip_confirm_prompt: Optional[bool] = SKIP_CONFIRM_PROMPT,
     current_version: Optional[str] = CURRENT_VERSION,
     commit: Optional[GitAction] = COMMIT,
     branch: Optional[GitAction] = BRANCH,
@@ -166,6 +180,7 @@ def by(
                 config_file=config_file,
                 project_root=project_root,
                 dry_run=dry_run,
+                skip_confirm_prompt=skip_confirm_prompt,
                 current_version=current_version_parsed,
                 commit=commit,
                 branch=branch,

--- a/hyper_bump_it/_config/application.py
+++ b/hyper_bump_it/_config/application.py
@@ -57,6 +57,7 @@ class Config:
     files: list[File]
     git: Git
     dry_run: bool
+    show_confirm_prompt: bool
     config_version_updater: Optional[file.ConfigVersionUpdater]
 
 
@@ -88,6 +89,9 @@ def config_for_bump_to(args: BumpToArgs) -> Config:
         files=_convert_files(file_config.files),
         git=_convert_git(args, file_config.git),
         dry_run=args.dry_run,
+        show_confirm_prompt=_show_confirm_prompt(
+            file_config.show_confirm_prompt, args.skip_confirm_prompt
+        ),
         config_version_updater=version_updater,
     )
 
@@ -114,6 +118,9 @@ def config_for_bump_by(args: BumpByArgs) -> Config:
         files=_convert_files(file_config.files),
         git=_convert_git(args, file_config.git),
         dry_run=args.dry_run,
+        show_confirm_prompt=_show_confirm_prompt(
+            file_config.show_confirm_prompt, args.skip_confirm_prompt
+        ),
         config_version_updater=version_updater,
     )
 
@@ -161,4 +168,14 @@ def _convert_git(args: Union[BumpToArgs, BumpByArgs], git: file.Git) -> Git:
             branch=args.branch or git.actions.branch,
             tag=args.tag or git.actions.tag,
         ),
+    )
+
+
+def _show_confirm_prompt(
+    file_show_confirm: bool, cli_skip_confirm_prompt: Optional[bool]
+) -> bool:
+    return (
+        file_show_confirm
+        if cli_skip_confirm_prompt is None
+        else not cli_skip_confirm_prompt
     )

--- a/hyper_bump_it/_config/cli.py
+++ b/hyper_bump_it/_config/cli.py
@@ -20,6 +20,7 @@ class BumpToArgs:
     config_file: Optional[Path]
     project_root: Path
     dry_run: bool
+    skip_confirm_prompt: Optional[bool]
     current_version: Optional[Version]
     commit: Optional[GitAction]
     branch: Optional[GitAction]
@@ -36,6 +37,7 @@ class BumpByArgs:
     config_file: Optional[Path]
     project_root: Path
     dry_run: bool
+    skip_confirm_prompt: Optional[bool]
     current_version: Optional[Version]
     commit: Optional[GitAction]
     branch: Optional[GitAction]

--- a/hyper_bump_it/_config/file.py
+++ b/hyper_bump_it/_config/file.py
@@ -108,6 +108,7 @@ class ValidVersion(Version):  # type: ignore[misc]
 class ConfigFile(HyperBaseMode):
     files: list[File] = Field(..., min_items=1)
     current_version: Optional[ValidVersion] = None
+    show_confirm_prompt: StrictBool = True
     git: Git = Git()
 
     @root_validator(skip_on_failure=True)

--- a/hyper_bump_it/_core.py
+++ b/hyper_bump_it/_core.py
@@ -35,12 +35,13 @@ def do_bump(config: Config) -> None:
     if config.dry_run:
         return
 
-    response = prompt.Confirm.ask(
-        "Do you want to perform these actions?", default=False
-    )
+    if config.show_confirm_prompt:
+        response = prompt.Confirm.ask(
+            "Do you want to perform these actions?", default=False
+        )
 
-    if not response:
-        return
+        if not response:
+            return
 
     plan.execute_plan()
 

--- a/tests/config/test_application.py
+++ b/tests/config/test_application.py
@@ -220,6 +220,55 @@ def test_config_for_bump_to__cli_dry_run__values_has_dry_run(
     )
 
 
+@pytest.mark.parametrize(
+    [
+        "file_show_confirm_prompt",
+        "cli_skip_confirm_prompt",
+        "expected_show_confirm_prompt",
+    ],
+    [
+        (None, None, True),
+        (None, True, False),
+        (None, False, True),
+        (True, None, True),
+        (True, True, False),
+        (True, False, True),
+        (False, None, False),
+        (False, True, False),
+        (False, False, True),
+    ],
+)
+def test_config_for_bump_to__show_confirm_prompt_values__expected_result(
+    file_show_confirm_prompt,
+    cli_skip_confirm_prompt,
+    expected_show_confirm_prompt,
+    tmp_path: Path,
+):
+    config_file = tmp_path / sd.SOME_CONFIG_FILE_NAME
+    config_file.write_text(
+        sd.some_minimal_config_text(
+            file.ROOT_TABLE_KEY,
+            version=sd.SOME_VERSION,
+            show_confirm_prompt=file_show_confirm_prompt,
+        )
+    )
+
+    config = application.config_for_bump_to(
+        sd.no_config_override_bump_to_args(
+            skip_confirm_prompt=cli_skip_confirm_prompt,
+            config_file=config_file,
+            project_root=tmp_path,
+        )
+    )
+
+    assert config == sd.some_application_config(
+        files=[_default_file(file_glob=sd.SOME_FILE_GLOB)],
+        git=_default_git(),
+        show_confirm_prompt=expected_show_confirm_prompt,
+        project_root=tmp_path,
+    )
+
+
 def test_config_for_bump_to__keystone_glob_no_match__error(tmp_path: Path):
     config_file = tmp_path / sd.SOME_CONFIG_FILE_NAME
     config_file.write_text(
@@ -363,6 +412,56 @@ def test_config_for_bump_by__cli_dry_run__values_has_dry_run(
         git=_default_git(),
         project_root=tmp_path,
         dry_run=True,
+    )
+
+
+@pytest.mark.parametrize(
+    [
+        "file_show_confirm_prompt",
+        "cli_skip_confirm_prompt",
+        "expected_show_confirm_prompt",
+    ],
+    [
+        (None, None, True),
+        (None, True, False),
+        (None, False, True),
+        (True, None, True),
+        (True, True, False),
+        (True, False, True),
+        (False, None, False),
+        (False, True, False),
+        (False, False, True),
+    ],
+)
+def test_config_for_bump_by__show_confirm_prompt_values__expected_result(
+    file_show_confirm_prompt,
+    cli_skip_confirm_prompt,
+    expected_show_confirm_prompt,
+    tmp_path: Path,
+):
+    config_file = tmp_path / sd.SOME_CONFIG_FILE_NAME
+    config_file.write_text(
+        sd.some_minimal_config_text(
+            file.ROOT_TABLE_KEY,
+            version=sd.SOME_VERSION,
+            show_confirm_prompt=file_show_confirm_prompt,
+        )
+    )
+
+    config = application.config_for_bump_by(
+        sd.no_config_override_bump_by_args(
+            skip_confirm_prompt=cli_skip_confirm_prompt,
+            config_file=config_file,
+            project_root=tmp_path,
+        )
+    )
+
+    assert config == sd.some_application_config(
+        new_version=sd.SOME_VERSION.next_minor(),
+        files=[_default_file(file_glob=sd.SOME_FILE_GLOB)],
+        git=_default_git(),
+        show_confirm_prompt=expected_show_confirm_prompt,
+        project_root=tmp_path,
     )
 
 

--- a/tests/config/test_file.py
+++ b/tests/config/test_file.py
@@ -271,7 +271,19 @@ def test_config_file__current_version_already_parsed__valid():
         ),
         (
             "git is an object with invalid fields",
-            {"git": SOME_INVALID_OBJECT},
+            {
+                "git": SOME_INVALID_OBJECT,
+                "current_version": sd.SOME_VERSION_STRING,
+                "files": [{"file_glob": sd.SOME_FILE_GLOB}],
+            },
+        ),
+        (
+            "show_confirm_prompt not bool",
+            {
+                "current_version": sd.SOME_VERSION_STRING,
+                "files": [{"file_glob": sd.SOME_FILE_GLOB}],
+                "show_confirm_prompt": SOME_NON_BOOL,
+            },
         ),
     ],
 )

--- a/tests/sample_data.py
+++ b/tests/sample_data.py
@@ -154,17 +154,25 @@ def some_git_operations_info(
     )
 
 
-def some_minimal_config_text(table_root: str, version: Optional[str]) -> str:
+def some_minimal_config_text(
+    table_root: str, version: Optional[str], show_confirm_prompt: Optional[bool] = None
+) -> str:
     if version is None:
         current_version = ""
         keystone = "keystone = true"
     else:
         current_version = f'current_version = "{version}"'
         keystone = ""
+    show_confirm_prompt_text = (
+        ""
+        if show_confirm_prompt is None
+        else f"show_confirm_prompt = {str(show_confirm_prompt).lower()}"
+    )
     return dedent(
         f"""\
         [{table_root}]
         {current_version}
+        {show_confirm_prompt_text}
         [[{table_root}.files]]
         file_glob = "{SOME_FILE_GLOB}"
         {keystone}
@@ -177,12 +185,14 @@ def no_config_override_bump_to_args(
     new_version: Version = SOME_OTHER_VERSION,
     config_file: Optional[Path] = None,
     dry_run: bool = False,
+    skip_confirm_prompt: Optional[bool] = None,
 ) -> BumpToArgs:
     return BumpToArgs(
         new_version=new_version,
         config_file=config_file,
         project_root=project_root,
         dry_run=dry_run,
+        skip_confirm_prompt=skip_confirm_prompt,
         current_version=None,
         commit=None,
         branch=None,
@@ -199,6 +209,7 @@ def some_bump_to_args(
     new_version: Version = SOME_OTHER_VERSION,
     config_file: Optional[Path] = None,
     dry_run: bool = False,
+    skip_confirm_prompt: Optional[bool] = None,
     current_version: Optional[Version] = SOME_OTHER_PARTIAL_VERSION,
     commit: Optional[GitAction] = SOME_COMMIT_ACTION,
     branch: Optional[GitAction] = SOME_BRANCH_ACTION,
@@ -213,6 +224,7 @@ def some_bump_to_args(
         config_file=config_file,
         project_root=project_root,
         dry_run=dry_run,
+        skip_confirm_prompt=skip_confirm_prompt,
         current_version=current_version,
         commit=commit,
         branch=branch,
@@ -229,12 +241,14 @@ def no_config_override_bump_by_args(
     part_to_bump: BumpPart = SOME_BUMP_PART,
     config_file: Optional[Path] = None,
     dry_run: bool = False,
+    skip_confirm_prompt: Optional[bool] = None,
 ) -> BumpByArgs:
     return BumpByArgs(
         part_to_bump=part_to_bump,
         config_file=config_file,
         project_root=project_root,
         dry_run=dry_run,
+        skip_confirm_prompt=skip_confirm_prompt,
         current_version=None,
         commit=None,
         branch=None,
@@ -251,6 +265,7 @@ def some_bump_by_args(
     part_to_bump: BumpPart = SOME_BUMP_PART,
     config_file: Optional[Path] = None,
     dry_run: bool = False,
+    skip_confirm_prompt: Optional[bool] = None,
     current_version: Optional[Version] = SOME_OTHER_PARTIAL_VERSION,
     commit: Optional[GitAction] = SOME_COMMIT_ACTION,
     branch: Optional[GitAction] = SOME_BRANCH_ACTION,
@@ -265,6 +280,7 @@ def some_bump_by_args(
         config_file=config_file,
         project_root=project_root,
         dry_run=dry_run,
+        skip_confirm_prompt=skip_confirm_prompt,
         current_version=current_version,
         commit=commit,
         branch=branch,
@@ -299,6 +315,7 @@ def some_application_config(
     files: Optional[list[File]] = None,
     git: Git = some_git(),
     dry_run: bool = False,
+    show_confirm_prompt: bool = True,
     config_version_updater: Optional[ConfigVersionUpdater] = AnyConfigVersionUpdater(),
 ) -> Config:
     if files is None:
@@ -310,6 +327,7 @@ def some_application_config(
         files=files,
         git=git,
         dry_run=dry_run,
+        show_confirm_prompt=show_confirm_prompt,
         config_version_updater=config_version_updater,
     )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,12 +9,11 @@ from tests import sample_data as sd
 
 runner = CliRunner()
 
-CLI_OVERRIDE_ARGS: list[str] = [
+CLI_OVERRIDE_ARGS_WITHOUT_DRY_RUN: list[str] = [
     "--config-file",
     sd.SOME_CONFIG_FILE_NAME,
     "--project-root",
     sd.SOME_DIRECTORY_NAME,
-    "--dry-run",
     "--current-version",
     sd.SOME_OTHER_PARTIAL_VERSION_STRING,
     "--commit",
@@ -31,6 +30,10 @@ CLI_OVERRIDE_ARGS: list[str] = [
     sd.SOME_BRANCH_PATTERN,
     "--tag-format-pattern",
     sd.SOME_TAG_PATTERN,
+]
+
+CLI_OVERRIDE_ARGS: list[str] = CLI_OVERRIDE_ARGS_WITHOUT_DRY_RUN + [
+    "--dry-run",
 ]
 
 
@@ -83,6 +86,74 @@ def test_to__valid__args_sent_to_config_for_bump_to(mocker):
             config_file=Path(sd.SOME_CONFIG_FILE_NAME),
             project_root=Path(sd.SOME_DIRECTORY_NAME),
             dry_run=True,
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "dry_run_args",
+    [
+        (["--dry-run"]),
+        (["--no"]),
+        (["-n"]),
+        (["--dry-run", "--no-dry-run", "--dry-run"]),
+    ],
+)
+def test_to__dry_run_options__args_sent_to_config_for_bump_to(dry_run_args, mocker):
+    mock_config_for_bump_to = mocker.patch("hyper_bump_it._cli.config_for_bump_to")
+    mocker.patch("hyper_bump_it._core.do_bump")
+
+    result = runner.invoke(
+        cli.app,
+        [
+            "to",
+            sd.SOME_OTHER_VERSION_STRING,
+            *CLI_OVERRIDE_ARGS_WITHOUT_DRY_RUN,
+            *dry_run_args,
+        ],
+    )
+
+    _assert_success(result)
+    mock_config_for_bump_to.assert_called_once_with(
+        sd.some_bump_to_args(
+            config_file=Path(sd.SOME_CONFIG_FILE_NAME),
+            project_root=Path(sd.SOME_DIRECTORY_NAME),
+            dry_run=True,
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "skip_confirm_prompt_args",
+    [
+        (["--yes"]),
+        (["-y"]),
+        (["--yes", "--interactive", "--yes"]),
+    ],
+)
+def test_to__skip_confirm_prompt_options__args_sent_to_config_for_bump_to(
+    skip_confirm_prompt_args, mocker
+):
+    mock_config_for_bump_to = mocker.patch("hyper_bump_it._cli.config_for_bump_to")
+    mocker.patch("hyper_bump_it._core.do_bump")
+
+    result = runner.invoke(
+        cli.app,
+        [
+            "to",
+            sd.SOME_OTHER_VERSION_STRING,
+            *CLI_OVERRIDE_ARGS,
+            *skip_confirm_prompt_args,
+        ],
+    )
+
+    _assert_success(result)
+    mock_config_for_bump_to.assert_called_once_with(
+        sd.some_bump_to_args(
+            config_file=Path(sd.SOME_CONFIG_FILE_NAME),
+            project_root=Path(sd.SOME_DIRECTORY_NAME),
+            dry_run=True,
+            skip_confirm_prompt=True,
         )
     )
 
@@ -143,6 +214,99 @@ def test_by__valid__args_sent_to_config_for_bump_by(mocker):
             config_file=Path(sd.SOME_CONFIG_FILE_NAME),
             project_root=Path(sd.SOME_DIRECTORY_NAME),
             dry_run=True,
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "dry_run_args",
+    [
+        (["--dry-run"]),
+        (["--no"]),
+        (["-n"]),
+        (["--dry-run", "--no-dry-run", "--dry-run"]),
+    ],
+)
+def test_by__dry_run_options__args_sent_to_config_for_bump_by(dry_run_args, mocker):
+    mock_config_for_bump_to = mocker.patch("hyper_bump_it._cli.config_for_bump_by")
+    mocker.patch("hyper_bump_it._core.do_bump")
+
+    result = runner.invoke(
+        cli.app,
+        [
+            "by",
+            sd.SOME_BUMP_PART.value,
+            *CLI_OVERRIDE_ARGS_WITHOUT_DRY_RUN,
+            *dry_run_args,
+        ],
+    )
+
+    _assert_success(result)
+    mock_config_for_bump_to.assert_called_once_with(
+        sd.some_bump_by_args(
+            config_file=Path(sd.SOME_CONFIG_FILE_NAME),
+            project_root=Path(sd.SOME_DIRECTORY_NAME),
+            dry_run=True,
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "skip_confirm_prompt_args",
+    [
+        (["--yes"]),
+        (["-y"]),
+        (["--yes", "--interactive", "--yes"]),
+    ],
+)
+def test_by__skip_confirm_prompt_options__args_sent_to_config_for_bump_by(
+    skip_confirm_prompt_args, mocker
+):
+    mock_config_for_bump_to = mocker.patch("hyper_bump_it._cli.config_for_bump_by")
+    mocker.patch("hyper_bump_it._core.do_bump")
+
+    result = runner.invoke(
+        cli.app,
+        [
+            "by",
+            sd.SOME_BUMP_PART.value,
+            *CLI_OVERRIDE_ARGS,
+            *skip_confirm_prompt_args,
+        ],
+    )
+
+    _assert_success(result)
+    mock_config_for_bump_to.assert_called_once_with(
+        sd.some_bump_by_args(
+            config_file=Path(sd.SOME_CONFIG_FILE_NAME),
+            project_root=Path(sd.SOME_DIRECTORY_NAME),
+            dry_run=True,
+            skip_confirm_prompt=True,
+        )
+    )
+
+
+def test_by__interactive_option__args_sent_to_config_for_bump_by(mocker):
+    mock_config_for_bump_to = mocker.patch("hyper_bump_it._cli.config_for_bump_by")
+    mocker.patch("hyper_bump_it._core.do_bump")
+
+    result = runner.invoke(
+        cli.app,
+        [
+            "by",
+            sd.SOME_BUMP_PART.value,
+            *CLI_OVERRIDE_ARGS,
+            "--interactive",
+        ],
+    )
+
+    _assert_success(result)
+    mock_config_for_bump_to.assert_called_once_with(
+        sd.some_bump_by_args(
+            config_file=Path(sd.SOME_CONFIG_FILE_NAME),
+            project_root=Path(sd.SOME_DIRECTORY_NAME),
+            dry_run=True,
+            skip_confirm_prompt=False,
         )
     )
 


### PR DESCRIPTION
Adds functionality to control the prompt with the configuration file. The CLI also gained options that can be used to override the configuration file.

Fixes #51