### PR TITLE
Initialization of git settings

### DIFF
--- a/hyper_bump_it/_cli/init.py
+++ b/hyper_bump_it/_cli/init.py
@@ -29,7 +29,7 @@ from hyper_bump_it._config import (
     GitActionsConfigFile,
     GitConfigFile,
 )
-from hyper_bump_it._error import ConfigurationFileReadError
+from hyper_bump_it._error import ConfigurationFileReadError, first_error_message
 
 GIT_PANEL_NAME = "Git Configuration Options"
 
@@ -74,7 +74,7 @@ def init_command(
     try:
         actions = GitActionsConfigFile(commit=commit, branch=branch, tag=tag)
     except ValidationError as ex:
-        common.display_and_exit(_first_error_message(ex), exit_code=2)
+        common.display_and_exit(first_error_message(ex), exit_code=2)
 
     config = ConfigFile(
         current_version=version,
@@ -129,7 +129,3 @@ def _config_to_dict(config: ConfigFile) -> dict:  # type: ignore[type-arg]
     if config.current_version is not None:
         config_dict["current_version"] = str(config.current_version)
     return {ROOT_TABLE_KEY: config_dict}
-
-
-def _first_error_message(ex: ValidationError) -> str:
-    return ex.errors()[0]["msg"]

--- a/hyper_bump_it/_cli/interactive/git.py
+++ b/hyper_bump_it/_cli/interactive/git.py
@@ -1,12 +1,185 @@
 """
 Go through a series of prompts to construct a custom Git integration configuration.
 """
-from hyper_bump_it._config import GitConfigFile
+from enum import Enum
+from typing import Optional, TypeVar
+
+from pydantic import ValidationError
+from rich import print, prompt
+
+from hyper_bump_it._cli.interactive.prompt import enum_prompt
+from hyper_bump_it._config import (
+    DEFAULT_BRANCH_ACTION,
+    DEFAULT_BRANCH_FORMAT_PATTERN,
+    DEFAULT_COMMIT_ACTION,
+    DEFAULT_COMMIT_FORMAT_PATTERN,
+    DEFAULT_REMOTE,
+    DEFAULT_TAG_ACTION,
+    DEFAULT_TAG_FORMAT_PATTERN,
+    GitAction,
+    GitActionsConfigFile,
+    GitConfigFile,
+)
+from hyper_bump_it._error import first_error_message
+
+
+class GitMenu(Enum):
+    Remote = "remote"
+    CommitFormatPattern = "commit"
+    BranchFormatPattern = "branch"
+    TagFormatPattern = "tag"
+    Actions = "actions"
+    Done = "done"
 
 
 class GitConfigEditor:
     def __init__(self, initial_config: GitConfigFile) -> None:
-        self._config = initial_config.copy(deep=True)
+        self._config: GitConfigFile = initial_config.copy(deep=True)
+        self._config_funcs = {
+            GitMenu.Remote: self._configure_remote,
+            GitMenu.CommitFormatPattern: self._configure_commit_format_pattern,
+            GitMenu.BranchFormatPattern: self._configure_branch_format_pattern,
+            GitMenu.TagFormatPattern: self._configure_tag_format_pattern,
+            GitMenu.Actions: self._configure_actions,
+        }
 
     def configure(self) -> GitConfigFile:
+        """
+        Use interactive prompts to allow the user to edit the configuration.
+
+        :return: Configuration with the user's edits.
+        """
+        while (selection := _prompt_git_menu()) is not GitMenu.Done:
+            self._config_funcs[selection]()
+
         return self._config
+
+    def _configure_remote(self) -> None:
+        self._store_update("remote", _prompt_remote(self._config.remote))
+
+    def _configure_commit_format_pattern(self) -> None:
+        self._configure_format_pattern(
+            "commit message",
+            "commit_format_pattern",
+            self._config.commit_format_pattern,
+            DEFAULT_COMMIT_FORMAT_PATTERN,
+        )
+
+    def _configure_branch_format_pattern(self) -> None:
+        self._configure_format_pattern(
+            "branch name",
+            "branch_format_pattern",
+            self._config.branch_format_pattern,
+            DEFAULT_BRANCH_FORMAT_PATTERN,
+        )
+
+    def _configure_tag_format_pattern(self) -> None:
+        self._configure_format_pattern(
+            "tag name",
+            "tag_format_pattern",
+            self._config.tag_format_pattern,
+            DEFAULT_TAG_FORMAT_PATTERN,
+        )
+
+    def _configure_format_pattern(
+        self, name: str, config_name: str, current_pattern: str, default: str
+    ) -> None:
+        self._store_update(
+            config_name, _prompt_format_pattern(name, current_pattern, default)
+        )
+
+    def _store_update(self, config_name: str, value: Optional[str]) -> None:
+        if value is not None:
+            self._config = self._config.copy(update={config_name: value})
+
+    def _configure_actions(self) -> None:
+        print("There are three Git actions: create, branch, tag")
+        print(
+            "They can each be set to: "
+            f"{GitAction.Skip.value}, {GitAction.Create.value}, {GitAction.CreateAndPush.value}"
+        )
+        print(
+            "However, some combinations are not valid. If an invalid combination is detected,"
+            " an error message will be displayed before requesting new values for each action."
+        )
+        while True:
+            updated_commit = _prompt_action(
+                "commit", self._config.actions.commit, DEFAULT_COMMIT_ACTION
+            )
+            updated_branch = _prompt_action(
+                "branch", self._config.actions.branch, DEFAULT_BRANCH_ACTION
+            )
+            updated_tag = _prompt_action(
+                "tag", self._config.actions.tag, DEFAULT_TAG_ACTION
+            )
+            try:
+                actions = GitActionsConfigFile(
+                    commit=updated_commit, branch=updated_branch, tag=updated_tag
+                )
+                break
+            except ValidationError as ex:
+                print(f"[prompt.invalid]Error[/]: {first_error_message(ex)}")
+
+        self._config = self._config.copy(update={"actions": actions})
+
+
+def _prompt_git_menu() -> GitMenu:
+    return enum_prompt(
+        "What part of configuration would you like to edit?",
+        option_descriptions={
+            GitMenu.Remote: "Name of remote to use when pushing changes",
+            GitMenu.CommitFormatPattern: "Format pattern to use for commit message",
+            GitMenu.BranchFormatPattern: "Format pattern to use for branch name",
+            GitMenu.TagFormatPattern: "Format pattern to use for tag name",
+            GitMenu.Actions: "Configure what Git actions should be performed",
+            GitMenu.Done: "Stop editing the Git integration settings",
+        },
+        default=GitMenu.Done,
+    )
+
+
+def _prompt_remote(current_remote: str) -> Optional[str]:
+    return prompt.Prompt.ask(
+        f"When an action is set to 'create-and-push`, the name of the remote repository is needed."
+        f"The remote is currently set to: "
+        f"[bold]{current_remote}[/]{_default_message(current_remote, DEFAULT_REMOTE)}\n"
+        "Enter a new name or leave it blank to keep the value",
+        show_default=False,
+        default=None,
+    )
+
+
+def _prompt_format_pattern(
+    name: str, current_pattern: str, default: str
+) -> Optional[str]:
+    return prompt.Prompt.ask(
+        f"Format patterns are used to generate text. "
+        f"The format pattern for {name} is currently set to: "
+        f"[bold]{current_pattern}[/]{_default_message(current_pattern, default)}\n"
+        "Enter a new format pattern or leave it blank to keep the value",
+        show_default=False,
+        default=None,
+    )
+
+
+def _prompt_action(
+    name: str, current_value: GitAction, default: GitAction
+) -> GitAction:
+    selection = prompt.Prompt.ask(
+        f"The {name} action is currently set to: "
+        f"[bold]{current_value.value}[/]{_default_message(current_value, default)}\n"
+        "Enter a new value or leave it blank to keep the value",
+        choices=[option.value for option in GitAction],
+        show_default=False,
+        default=None,
+    )
+    if selection is None:
+        return current_value
+    return GitAction(selection)
+
+
+T = TypeVar("T")
+
+
+def _default_message(current_value: T, default: T) -> str:
+    return " [prompt.default](the default)[/]" if current_value == default else ""

--- a/hyper_bump_it/_cli/interactive/top_level.py
+++ b/hyper_bump_it/_cli/interactive/top_level.py
@@ -90,7 +90,7 @@ def _prompt_top_level_menu() -> TopMenu:
     )
 
 
-def _prompt_current_version(current_version: Version) -> Version:
+def _prompt_current_version(current_version: Version) -> Optional[Version]:
     result_value = VersionPrompt.ask(
         f"The current version is {current_version}.\n"
         "Enter a new version or leave it blank to keep the current version",

--- a/hyper_bump_it/_error.py
+++ b/hyper_bump_it/_error.py
@@ -358,6 +358,10 @@ class InvalidConfigurationError(ConfigurationError):
         )
 
 
+def first_error_message(ex: ValidationError) -> str:
+    return ex.errors()[0]["msg"]
+
+
 # rich specific functionality
 _RICH_STYLE_VALID = "green"
 _RICH_STYLE_INVALID = "bold red"

--- a/tests/cli/interactive/test_git.py
+++ b/tests/cli/interactive/test_git.py
@@ -1,0 +1,205 @@
+from io import StringIO
+
+from hyper_bump_it._cli.interactive import git
+from hyper_bump_it._cli.interactive.git import GitMenu
+from hyper_bump_it._config import GitAction
+from tests import sample_data as sd
+from tests.conftest import ForceInput
+
+
+def test_configure__no_changes__same_config(force_input: ForceInput):
+    force_input(force_input.NO_INPUT)
+    initial_config = sd.some_git_config_file(
+        remote=sd.SOME_OTHER_REMOTE, commit_format_pattern=sd.SOME_OTHER_COMMIT_PATTERN
+    )
+    editor = git.GitConfigEditor(initial_config)
+
+    result = editor.configure()
+
+    assert result == initial_config
+
+
+def test_configure__remote_value__updated_remote(force_input: ForceInput):
+    force_input(GitMenu.Remote.value, sd.SOME_OTHER_REMOTE, force_input.NO_INPUT)
+    editor = git.GitConfigEditor(sd.some_git_config_file())
+
+    result = editor.configure()
+
+    assert result == sd.some_git_config_file(remote=sd.SOME_OTHER_REMOTE)
+
+
+def test_configure__remote_no_input__unchanged_remote(force_input: ForceInput):
+    force_input(GitMenu.Remote.value, force_input.NO_INPUT, force_input.NO_INPUT)
+    initial_config = sd.some_git_config_file(remote=sd.SOME_OTHER_REMOTE)
+    editor = git.GitConfigEditor(initial_config)
+
+    result = editor.configure()
+
+    assert result == initial_config
+
+
+def test_configure__commit_format_pattern_value__updated_pattern(
+    force_input: ForceInput,
+):
+    force_input(
+        GitMenu.CommitFormatPattern.value,
+        sd.SOME_OTHER_COMMIT_PATTERN,
+        force_input.NO_INPUT,
+    )
+    editor = git.GitConfigEditor(sd.some_git_config_file())
+
+    result = editor.configure()
+
+    assert result == sd.some_git_config_file(
+        commit_format_pattern=sd.SOME_OTHER_COMMIT_PATTERN
+    )
+
+
+def test_configure__commit_format_pattern_no_input__unchanged_pattern(
+    force_input: ForceInput,
+):
+    force_input(
+        GitMenu.CommitFormatPattern.value, force_input.NO_INPUT, force_input.NO_INPUT
+    )
+    initial_config = sd.some_git_config_file(
+        commit_format_pattern=sd.SOME_OTHER_COMMIT_PATTERN
+    )
+    editor = git.GitConfigEditor(initial_config)
+
+    result = editor.configure()
+
+    assert result == initial_config
+
+
+def test_configure__branch_format_pattern_value__updated_pattern(
+    force_input: ForceInput,
+):
+    force_input(
+        GitMenu.BranchFormatPattern.value,
+        sd.SOME_OTHER_BRANCH_PATTERN,
+        force_input.NO_INPUT,
+    )
+    editor = git.GitConfigEditor(sd.some_git_config_file())
+
+    result = editor.configure()
+
+    assert result == sd.some_git_config_file(
+        branch_format_pattern=sd.SOME_OTHER_BRANCH_PATTERN
+    )
+
+
+def test_configure__branch_format_pattern_no_input__unchanged_pattern(
+    force_input: ForceInput,
+):
+    force_input(
+        GitMenu.BranchFormatPattern.value, force_input.NO_INPUT, force_input.NO_INPUT
+    )
+    initial_config = sd.some_git_config_file(
+        branch_format_pattern=sd.SOME_OTHER_BRANCH_PATTERN
+    )
+    editor = git.GitConfigEditor(initial_config)
+
+    result = editor.configure()
+
+    assert result == initial_config
+
+
+def test_configure__tag_format_pattern_value__updated_pattern(
+    force_input: ForceInput,
+):
+    force_input(
+        GitMenu.TagFormatPattern.value, sd.SOME_OTHER_TAG_PATTERN, force_input.NO_INPUT
+    )
+    editor = git.GitConfigEditor(sd.some_git_config_file())
+
+    result = editor.configure()
+
+    assert result == sd.some_git_config_file(
+        tag_format_pattern=sd.SOME_OTHER_TAG_PATTERN
+    )
+
+
+def test_configure__tag_format_pattern_no_input__unchanged_pattern(
+    force_input: ForceInput,
+):
+    force_input(
+        GitMenu.TagFormatPattern.value, force_input.NO_INPUT, force_input.NO_INPUT
+    )
+    initial_config = sd.some_git_config_file(
+        tag_format_pattern=sd.SOME_OTHER_TAG_PATTERN
+    )
+    editor = git.GitConfigEditor(initial_config)
+
+    result = editor.configure()
+
+    assert result == initial_config
+
+
+def test_configure__actions_values__updated_actions(
+    force_input: ForceInput,
+):
+    force_input(
+        GitMenu.Actions.value,
+        GitAction.CreateAndPush.value,
+        GitAction.Skip.value,
+        GitAction.Create.value,
+        force_input.NO_INPUT,
+    )
+    editor = git.GitConfigEditor(sd.some_git_config_file())
+
+    result = editor.configure()
+
+    assert result == sd.some_git_config_file(
+        actions=sd.some_git_actions_config_file(
+            commit=GitAction.CreateAndPush, branch=GitAction.Skip, tag=GitAction.Create
+        )
+    )
+
+
+def test_configure__actions_no_input__unchanged_actions(
+    force_input: ForceInput,
+):
+    initial_config = sd.some_git_config_file(
+        actions=sd.some_git_actions_config_file(
+            commit=GitAction.CreateAndPush, branch=GitAction.Skip, tag=GitAction.Create
+        )
+    )
+    force_input(
+        GitMenu.Actions.value,
+        force_input.NO_INPUT,
+        force_input.NO_INPUT,
+        force_input.NO_INPUT,
+        force_input.NO_INPUT,
+    )
+    editor = git.GitConfigEditor(initial_config)
+
+    result = editor.configure()
+
+    assert result == initial_config
+
+
+def test_configure__actions_invalid_combination__ask_all_again(
+    force_input: ForceInput, capture_rich: StringIO
+):
+    force_input(
+        GitMenu.Actions.value,
+        GitAction.Skip.value,
+        GitAction.Skip.value,
+        GitAction.Create.value,
+        GitAction.CreateAndPush.value,
+        GitAction.Skip.value,
+        GitAction.Create.value,
+        force_input.NO_INPUT,
+    )
+    editor = git.GitConfigEditor(sd.some_git_config_file())
+
+    result = editor.configure()
+
+    assert result == sd.some_git_config_file(
+        actions=sd.some_git_actions_config_file(
+            commit=GitAction.CreateAndPush, branch=GitAction.Skip, tag=GitAction.Create
+        )
+    )
+    assert (
+        "Error: if commit is 'skip', tag must also be 'skip'" in capture_rich.getvalue()
+    )

--- a/tests/cli/interactive/test_top_level.py
+++ b/tests/cli/interactive/test_top_level.py
@@ -1,6 +1,3 @@
-"""
-
-"""
 import pytest
 
 from hyper_bump_it._cli.interactive import top_level


### PR DESCRIPTION
Also:
* Move first_error_message() to a reusable location
* Correct type hint for _prompt_current_version()
* Remove empty test file docstring

Fixes #89