### PR TITLE
Add pipeline for automating the creation and upload of a new release

### DIFF
--- a/.github/workflows/detect_version_bump.yml
+++ b/.github/workflows/detect_version_bump.yml
@@ -1,0 +1,36 @@
+name: Version Bump merged
+
+on:
+  pull_request:
+    types:
+      - "closed"
+    branches:
+      - "main"
+
+jobs:
+  trigger-release:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged &&
+        startsWith(github.head_ref, 'bump_version_to_') &&
+        startsWith(github.event.pull_request.title, 'Bump version') &&
+        contains(github.event.pull_request.title, ' → ')
+    environment: "Create Release"
+    steps:
+      - name: Get new version
+        id: get-new-version
+        run: |
+          NEW_VERSION=$(echo ${{ github.head_ref }} | cut -d _ -f4 )
+          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+      - name: Is prerelease?
+        id: is-prerelease
+        run: |
+          IS_PRERELEASE=$([[ "${{ steps.get-new-version.outputs.version }}" == *-[a-z]* ]] && echo true || echo false)
+          echo "result=$IS_PRERELEASE" >> $GITHUB_OUTPUT
+      - name: Create Release
+        uses: ncipollo/release-action@a2e71bdd4e7dab70ca26a852f29600c98b33153e # v1.12.0
+        with:
+          token: ${{ secrets.CREATE_RELEASE_TOKEN }}
+          tag: v${{ steps.get-new-version.outputs.version }}
+          name: v${{ steps.get-new-version.outputs.version }} Release
+          commit: main
+          prerelease: ${{ steps.is-prerelease.outputs.result }}

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,0 +1,50 @@
+name: Publish Release
+
+env:
+  PYTHON_VERSION: "3.11"
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update_docs_for_version_bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
+
+      - uses: actions/setup-python@5ccb29d8773c3f3f653e1705f474dfaa8a06a912 # v4.4.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install dependencies
+        uses: ./.github/actions/install-dependencies
+        with:
+          requirements: "true"
+          test-requirements: "true"
+          docs-requirements: "true"
+
+      - name: Push documentation changes
+        uses: ./.github/actions/publish-docs-with-mike
+        with:
+          new_version: true
+
+  build-and-publish-wheel-to-pypi:
+    runs-on: ubuntu-latest
+    environment: "Upload Release"
+    steps:
+      - name: Check out code
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
+
+      - uses: actions/setup-python@5ccb29d8773c3f3f653e1705f474dfaa8a06a912 # v4.4.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Build wheel
+        uses: ./.github/actions/build-dist
+
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@c7f29f7adef1a245bd91520e94867e5c6eedddcc # v1.6.4
+        with:
+          password: ${{ secrets.PYPI_UPLOAD_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Internal
 
 * Use `hyper-bump-it` to manage the version of the project.
+* Automate the release process of new versions.
 * Reorganize internal modules under a single internal sub-module.
 * Remove dependency on `semantic-version`.
 


### PR DESCRIPTION
Project changes not captured by PR.

* Create GitHub access token for this repo with content permissions (tightest that supports creating a release).
* Create a new PyPI upload token
* Create two GitHub environments:
  * Create Release: Used by version bump detection workflow.
  * Upload Release: Used by artifact upload workflow

Fixes #87 