### PR TITLE
Escape user supplied text that is displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Incorrectly display of planned change for lines that contained leading whitespace characters.
+* Incorrectly display of text containing square brackets (`[`, `]`).
 
 ## [0.3.0] - 2023-01-26
 

--- a/hyper_bump_it/_hyper_bump_it/cli/interactive/files.py
+++ b/hyper_bump_it/_hyper_bump_it/cli/interactive/files.py
@@ -5,6 +5,7 @@ from enum import Enum
 from typing import Optional
 
 from rich import print, prompt
+from rich.markup import escape
 from rich.text import Text
 
 from ...config import DEFAULT_SEARCH_PATTERN, FileDefinition
@@ -80,7 +81,7 @@ class FilesConfigEditor:
     def _list_definitions(self) -> None:
         print("The current file definitions:")
         for definition in self._config:
-            print(_definition_summary(definition))
+            print(escape(_definition_summary(definition)))
 
 
 def _prompt_file_menu() -> FilesMenu:
@@ -104,7 +105,7 @@ def _prompt_file_glob(default: Optional[str]) -> str:
         )
     else:
         file_glob = prompt.Prompt.ask(
-            f"The current file glob pattern is '{default}'.\n"
+            f"The current file glob pattern is '{escape(default)}'.\n"
             f"Enter a new glob pattern or leave it blank to kep the current file glob pattern",
             show_default=False,
             default=default,
@@ -152,7 +153,7 @@ def _prompt_definition(
             return definition
 
         print("The configured file definition was not valid:")
-        print(result.description)
+        print(escape(result.description))
         print("Update the definition to address the issue.")
         # Replace current with the new definition so the prompt defaults match what the user
         # entered. This allows the user to quickly get to the prompt that needs to be addressed.
@@ -185,7 +186,7 @@ def _prompt_keystone(default: bool) -> bool:
 def _prompt_format_pattern(name: str, current: str, new: bool) -> str:
     description = "default" if new else "current"
     return prompt.Prompt.ask(
-        f"The {description} {name} format pattern is '{current}'.\n"
+        f"The {description} {name} format pattern is '{escape(current)}'.\n"
         f"Enter a new format pattern or leave it blank to kep the {description} format pattern",
         show_default=False,
         default=current,

--- a/hyper_bump_it/_hyper_bump_it/cli/interactive/git.py
+++ b/hyper_bump_it/_hyper_bump_it/cli/interactive/git.py
@@ -6,6 +6,7 @@ from typing import Optional, TypeVar, Union
 
 from pydantic import ValidationError
 from rich import print, prompt
+from rich.markup import escape
 
 from ...config import (
     DEFAULT_BRANCH_ACTION,
@@ -134,7 +135,7 @@ class GitConfigEditor:
                 )
                 break
             except ValidationError as ex:
-                print(f"[prompt.invalid]Error[/]: {first_error_message(ex)}")
+                print(f"[prompt.invalid]Error[/]: {escape(first_error_message(ex))}")
 
         self._config = self._config.copy(update={"actions": actions})
 
@@ -159,7 +160,7 @@ def _prompt_remote(current_remote: str) -> Optional[str]:
     return prompt.Prompt.ask(
         f"When an action is set to 'create-and-push`, the name of the remote repository is needed."
         f"The remote is currently set to: "
-        f"[bold]{current_remote}[/]{_default_message(current_remote, DEFAULT_REMOTE)}\n"
+        f"[bold]{escape(current_remote)}[/]{_default_message(current_remote, DEFAULT_REMOTE)}\n"
         "Enter a new name or leave it blank to keep the value",
         show_default=False,
         default=None,
@@ -172,7 +173,7 @@ def _prompt_format_pattern(
     return prompt.Prompt.ask(
         f"Format patterns are used to generate text. "
         f"The format pattern for {name} is currently set to: "
-        f"[bold]{current_pattern}[/]{_default_message(current_pattern, default)}\n"
+        f"[bold]{escape(current_pattern)}[/]{_default_message(current_pattern, default)}\n"
         "Enter a new format pattern or leave it blank to keep the value",
         show_default=False,
         default=None,
@@ -283,10 +284,10 @@ def _display_branch_list(config: frozenset[str]) -> None:
         print("No allowed branches are currently set.")
     elif len(config) == 1:
         branch = next(iter(config))
-        print(f"The allowed branch is '{branch}'.")
+        print(f"The allowed branch is '{escape(branch)}'.")
     else:
         branches = "', '".join(config)
-        print(f"The allowed branches are: '{branches}'")
+        print(f"The allowed branches are: '{escape(branches)}'")
 
 
 def _prompt_add_branch() -> Optional[str]:

--- a/hyper_bump_it/_hyper_bump_it/error.py
+++ b/hyper_bump_it/_hyper_bump_it/error.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Collection, TypeVar
 
 from pydantic import ValidationError
+from rich.markup import escape
 
 if TYPE_CHECKING:
     from pydantic.error_wrappers import ErrorDict
@@ -34,7 +35,8 @@ class FormatKeyError(FormatError):
 
     def __rich__(self) -> str:
         return (
-            f"Format pattern '{_rich_invalid_value(self.format_pattern)}' used an invalid key.\n"
+            f"Format pattern '{_rich_invalid_value(escape(self.format_pattern))}' "
+            "used an invalid key.\n"
             f"Valid keys are: {_list_values(self.valid_keys, _rich_valid_value)}"
         )
 
@@ -81,7 +83,7 @@ class FormatPatternError(FormatError):
 
     def __rich__(self) -> str:
         return (
-            f"Format pattern '{_rich_invalid_value(self.format_pattern)}' was invalid:\n"
+            f"Format pattern '{_rich_invalid_value(escape(self.format_pattern))}' was invalid:\n"
             f"{_rich_error_message(self.error)}"
         )
 
@@ -99,7 +101,7 @@ class TodayFormatKeyError(FormatError):
 
     def __rich__(self) -> str:
         return (
-            f"Today format directive '{_rich_invalid_value(self.date_format_pattern)}' "
+            f"Today format directive '{_rich_invalid_value(escape(self.date_format_pattern))}' "
             "used an unsupported key for keystone parsing.\n"
             f"Valid keys are: {_list_values(self.valid_keys, _rich_valid_value)}"
         )
@@ -117,7 +119,7 @@ class IncompleteKeystoneVersionError(FormatError):
     def __rich__(self) -> str:
         return (
             f"Keystone version found in file '{_rich_path(self.file)}' using pattern "
-            f"'{_rich_invalid_value(self.search_pattern)}' was incomplete."
+            f"'{_rich_invalid_value(escape(self.search_pattern))}' was incomplete."
         )
 
 
@@ -131,7 +133,7 @@ class FileGlobError(BumpItError):
 
     def __rich__(self) -> str:
         return (
-            f"File glob '{_rich_file_glob(self.file_glob)}' did not match any files "
+            f"File glob '{_rich_file_glob(escape(self.file_glob))}' did not match any files "
             f"in '{_rich_path(self.working_dir)}'"
         )
 
@@ -153,7 +155,8 @@ class KeystoneFileGlobError(KeystoneError):
 
     def __rich__(self) -> str:
         return (
-            f"The file glob ({_rich_file_glob(self.file_glob)}) for the keystone files must match "
+            f"The file glob ({_rich_file_glob(escape(self.file_glob))}) for the keystone files "
+            "must match "
             f"exactly one file.\n{self._matched_description(_rich_path)}"
         )
 
@@ -175,7 +178,7 @@ class VersionNotFound(KeystoneError):
     def __rich__(self) -> str:
         return (
             f"Current version not found in file '{_rich_path(self.file)}' using pattern "
-            f"'{_rich_valid_value(self.search_pattern)}'"
+            f"'{_rich_valid_value(escape(self.search_pattern))}'"
         )
 
 
@@ -236,7 +239,7 @@ class MissingRemoteError(GitError):
     def __rich__(self) -> str:
         return (
             f"The repository at '{_rich_path(self.project_root)}' does not define the "
-            f"[bold]remote[/] '{_rich_valid_value(self.remote)}'"
+            f"[bold]remote[/] '{_rich_valid_value(escape(self.remote))}'"
         )
 
 
@@ -266,15 +269,15 @@ class DisallowedInitialBranchError(GitError):
 
     def __rich__(self) -> str:
         if len(self.allowed_initial_branches) == 1:
-            must_message = f"'{_rich_valid_value(self._first_branch)}'"
+            must_message = f"'{_rich_valid_value(escape(self._first_branch))}'"
         else:
             branches = "', '".join(
-                _rich_valid_value(x) for x in self.allowed_initial_branches
+                _rich_valid_value(escape(x)) for x in self.allowed_initial_branches
             )
             must_message = f"one of: '{branches}'"
         return (
             f"The repository at '{_rich_path(self.project_root)}' is current on branch "
-            f"'{_rich_invalid_value(self.active_branch)}', "
+            f"'{_rich_invalid_value(escape(self.active_branch))}', "
             f"which is not allowed. Must be {must_message}."
         )
 
@@ -292,7 +295,7 @@ class AlreadyExistsError(GitError):
     def __rich__(self) -> str:
         return (
             f"The repository at '{_rich_path(self.project_root)}' already has a "
-            f"{_rich_bold(self.ref_type)} named '{_rich_valid_value(self.name)}'"
+            f"{_rich_bold(self.ref_type)} named '{_rich_valid_value(escape(self.name))}'"
         )
 
 
@@ -325,7 +328,7 @@ class ConfigurationFileReadError(ConfigurationError):
     def __rich__(self) -> str:
         return (
             f"The configuration file ({_rich_path(self.file)}) could not be read:\n"
-            + _rich_error_message(str(self.cause))
+            + _rich_error_message(escape(str(self.cause)))
         )
 
 
@@ -340,7 +343,7 @@ class ConfigurationFileWriteError(ConfigurationError):
     def __rich__(self) -> str:
         return (
             f"The configuration file ({_rich_path(self.file)}) could not be written to:\n"
-            + _rich_error_message(str(self.cause))
+            + _rich_error_message(escape(str(self.cause)))
         )
 
 
@@ -384,7 +387,8 @@ class InvalidConfigurationError(ConfigurationError):
     @staticmethod
     def display_errors(errors: list["ErrorDict"]) -> str:
         return "\n".join(
-            f'{InvalidConfigurationError._display_error_loc(e)}  {_rich_error_message(e["msg"])}'
+            f"{InvalidConfigurationError._display_error_loc(e)}  "
+            f'{_rich_error_message(escape(e["msg"]))}'
             for e in errors
         )
 
@@ -423,7 +427,7 @@ def _rich_error_message(value: str) -> str:
 
 
 def _rich_path(value: Path) -> str:
-    return _rich_value(str(value), _RICH_STYLE_PATHLIKE)
+    return _rich_value(escape(str(value)), _RICH_STYLE_PATHLIKE)
 
 
 def _rich_file_glob(value: str) -> str:

--- a/hyper_bump_it/_hyper_bump_it/execution_plan.py
+++ b/hyper_bump_it/_hyper_bump_it/execution_plan.py
@@ -8,6 +8,7 @@ from typing import Optional, Protocol, TypeVar
 
 from git import Repo
 from rich import print
+from rich.markup import escape
 from rich.rule import Rule
 
 from . import files, vcs
@@ -101,14 +102,18 @@ class ChangeFileAction:
         self._change = change
 
     def __call__(self) -> None:
-        print(f"Updating {self._change.file}")
+        print(f"Updating {escape(str(self._change.file))}")
         files.perform_change(self._change)
 
     def display_intent(self) -> None:
-        print(Rule(title=str(self._change.file)))
+        print(Rule(title=escape(str(self._change.file))))
         for line_change in self._change.line_changes:
-            print(f"{line_change.line_index + 1}: [red]- {line_change.old_line}")
-            print(f"{line_change.line_index + 1}: [green]+ {line_change.new_line}")
+            print(
+                f"{line_change.line_index + 1}: [red]- {escape(line_change.old_line)}"
+            )
+            print(
+                f"{line_change.line_index + 1}: [green]+ {escape(line_change.new_line)}"
+            )
 
 
 def update_file_actions(planned_changes: list[files.PlannedChange]) -> Action:
@@ -125,11 +130,11 @@ class CreateBranchAction:
         self._branch_name = branch_name
 
     def __call__(self) -> None:
-        print(f"Creating branch {self._branch_name}")
+        print(f"Creating branch {escape(self._branch_name)}")
         vcs.create_branch(self._repo, self._branch_name)
 
     def display_intent(self) -> None:
-        print(f"Create branch {self._branch_name}")
+        print(f"Create branch {escape(self._branch_name)}")
 
 
 class SwitchBranchAction:
@@ -138,11 +143,11 @@ class SwitchBranchAction:
         self._branch_name = branch_name
 
     def __call__(self) -> None:
-        print(f"Switching to branch {self._branch_name}")
+        print(f"Switching to branch {escape(self._branch_name)}")
         vcs.switch_to(self._repo, self._branch_name)
 
     def display_intent(self) -> None:
-        print(f"Switch to branch {self._branch_name}")
+        print(f"Switch to branch {escape(self._branch_name)}")
 
 
 class CommitChangesAction:
@@ -151,11 +156,11 @@ class CommitChangesAction:
         self._commit_message = commit_message
 
     def __call__(self) -> None:
-        print(f"Committing changes: {self._commit_message}")
+        print(f"Committing changes: {escape(self._commit_message)}")
         vcs.commit_changes(self._repo, self._commit_message)
 
     def display_intent(self) -> None:
-        print(f"Commit changes: {self._commit_message}")
+        print(f"Commit changes: {escape(self._commit_message)}")
 
 
 class CreateTagAction:
@@ -164,11 +169,11 @@ class CreateTagAction:
         self._tag_name = tag_name
 
     def __call__(self) -> None:
-        print(f"Tagging commit: {self._tag_name}")
+        print(f"Tagging commit: {escape(self._tag_name)}")
         vcs.create_tag(self._repo, self._tag_name)
 
     def display_intent(self) -> None:
-        print(f"Tag commit: {self._tag_name}")
+        print(f"Tag commit: {escape(self._tag_name)}")
 
 
 class PushChangesAction:
@@ -185,11 +190,11 @@ class PushChangesAction:
 
     def _description(self, intent: bool) -> str:
         action = "Push" if intent else "Pushing"
-        message = f"{action} commit to {self._operation_info.remote}"
+        message = f"{action} commit to {escape(self._operation_info.remote)}"
         if self._operation_info.actions.branch == GitAction.CreateAndPush:
-            message = f"{message} on branch {self._operation_info.branch_name}"
+            message = f"{message} on branch {escape(self._operation_info.branch_name)}"
         if self._operation_info.actions.tag == GitAction.CreateAndPush:
-            message = f"{message} with tag {self._operation_info.tag_name}"
+            message = f"{message} with tag {escape(self._operation_info.tag_name)}"
         return message
 
 

--- a/tests/_hyper_bump_it/cli/interactive/test_git.py
+++ b/tests/_hyper_bump_it/cli/interactive/test_git.py
@@ -1,5 +1,7 @@
 from io import StringIO
 
+import pytest
+
 from hyper_bump_it._hyper_bump_it.cli.interactive import git
 from hyper_bump_it._hyper_bump_it.cli.interactive.git import (
     AllowedBranchesMenu,
@@ -44,6 +46,23 @@ def test_configure__remote_no_input__unchanged_remote(force_input: ForceInput):
     assert result == initial_config
 
 
+def test_configure__remote_require_escape__values_escaped(
+    force_input: ForceInput, capture_rich: StringIO
+):
+    force_input(
+        GitMenu.Remote.value,
+        force_input.NO_INPUT,
+        force_input.NO_INPUT,
+    )
+    editor = git.GitConfigEditor(
+        sd.some_git_config_file(remote=sd.SOME_ESCAPE_REQUIRED_TEXT)
+    )
+
+    editor.configure()
+
+    assert sd.SOME_ESCAPE_REQUIRED_TEXT in capture_rich.getvalue()
+
+
 def test_configure__commit_format_pattern_value__updated_pattern(
     force_input: ForceInput,
 ):
@@ -75,6 +94,23 @@ def test_configure__commit_format_pattern_no_input__unchanged_pattern(
     result = editor.configure()
 
     assert result == initial_config
+
+
+def test_configure__commit_format_pattern_require_escape__values_escaped(
+    force_input: ForceInput, capture_rich: StringIO
+):
+    force_input(
+        GitMenu.CommitFormatPattern.value,
+        force_input.NO_INPUT,
+        force_input.NO_INPUT,
+    )
+    editor = git.GitConfigEditor(
+        sd.some_git_config_file(commit_format_pattern=sd.SOME_ESCAPE_REQUIRED_TEXT)
+    )
+
+    editor.configure()
+
+    assert sd.SOME_ESCAPE_REQUIRED_TEXT in capture_rich.getvalue()
 
 
 def test_configure__branch_format_pattern_value__updated_pattern(
@@ -110,6 +146,23 @@ def test_configure__branch_format_pattern_no_input__unchanged_pattern(
     assert result == initial_config
 
 
+def test_configure__branch_format_pattern_require_escape__values_escaped(
+    force_input: ForceInput, capture_rich: StringIO
+):
+    force_input(
+        GitMenu.BranchFormatPattern.value,
+        force_input.NO_INPUT,
+        force_input.NO_INPUT,
+    )
+    editor = git.GitConfigEditor(
+        sd.some_git_config_file(branch_format_pattern=sd.SOME_ESCAPE_REQUIRED_TEXT)
+    )
+
+    editor.configure()
+
+    assert sd.SOME_ESCAPE_REQUIRED_TEXT in capture_rich.getvalue()
+
+
 def test_configure__tag_format_pattern_value__updated_pattern(
     force_input: ForceInput,
 ):
@@ -139,6 +192,23 @@ def test_configure__tag_format_pattern_no_input__unchanged_pattern(
     result = editor.configure()
 
     assert result == initial_config
+
+
+def test_configure__tag_format_pattern_require_escape__values_escaped(
+    force_input: ForceInput, capture_rich: StringIO
+):
+    force_input(
+        GitMenu.TagFormatPattern.value,
+        force_input.NO_INPUT,
+        force_input.NO_INPUT,
+    )
+    editor = git.GitConfigEditor(
+        sd.some_git_config_file(tag_format_pattern=sd.SOME_ESCAPE_REQUIRED_TEXT)
+    )
+
+    editor.configure()
+
+    assert sd.SOME_ESCAPE_REQUIRED_TEXT in capture_rich.getvalue()
 
 
 def test_configure__actions_values__updated_actions(
@@ -450,3 +520,30 @@ def test_configure_allowed_branches__start_default_remove_one__remaining_allowed
         allowed_initial_branches={to_remain},
         extend_allowed_initial_branches=set(),
     )
+
+
+@pytest.mark.parametrize(
+    "branches",
+    [
+        {sd.SOME_ESCAPE_REQUIRED_TEXT},
+        {sd.SOME_ESCAPE_REQUIRED_TEXT, sd.SOME_OTHER_ESCAPE_REQUIRED_TEXT},
+    ],
+)
+def test_configure_allowed_branches__require_escape__values_escaped(
+    branches, force_input: ForceInput, capture_rich: StringIO
+):
+    initial_config = sd.some_git_config_file(
+        allowed_initial_branches=branches,
+    )
+    force_input(
+        GitMenu.AllowedBranches.value,
+        force_input.NO_INPUT,
+        force_input.NO_INPUT,
+    )
+    editor = git.GitConfigEditor(initial_config)
+
+    editor.configure()
+
+    output = capture_rich.getvalue()
+    for branch in branches:
+        assert branch in output

--- a/tests/_hyper_bump_it/cli/interactive/test_prompt.py
+++ b/tests/_hyper_bump_it/cli/interactive/test_prompt.py
@@ -2,9 +2,11 @@ from enum import Enum
 from io import StringIO
 
 import pytest
+from rich import print as r_print
 from rich.text import Text
 
 from hyper_bump_it._hyper_bump_it.cli.interactive import prompt
+from tests._hyper_bump_it import sample_data as sd
 from tests.conftest import ForceInput
 
 
@@ -81,6 +83,27 @@ def test_enum_prompt__expected_output(force_input: ForceInput, capture_rich: Str
     )
 
 
+def test_enum_prompt__text_require_escape__values_escaped(
+    force_input: ForceInput, capture_rich: StringIO
+):
+    force_input(force_input.NO_INPUT)
+    prompt.enum_prompt(
+        sd.SOME_ESCAPE_REQUIRED_TEXT,
+        {
+            Options.Foo: sd.SOME_ESCAPE_REQUIRED_TEXT,
+            Options.Bar: sd.SOME_ESCAPE_REQUIRED_TEXT,
+        },
+        SOME_OPTION,
+    )
+
+    assert (
+        capture_rich.getvalue() == f"{sd.SOME_ESCAPE_REQUIRED_TEXT}\n"
+        f"{Options.Foo.value} - {sd.SOME_ESCAPE_REQUIRED_TEXT}\n"
+        f"{Options.Bar.value} - {sd.SOME_ESCAPE_REQUIRED_TEXT} (default)\n"
+        f"Enter the option name: "
+    )
+
+
 @pytest.mark.parametrize(
     ["options", "default", "expected_text"],
     [
@@ -114,3 +137,23 @@ def test_list_options__expected_output(options, default, expected_text):
     )
 
     assert text.plain == expected_text
+
+
+def test_list_options__text_require_escape__values_escaped(capture_rich: StringIO):
+    text = Text()
+
+    prompt.list_options(
+        text,
+        {
+            Options.Foo.value: sd.SOME_ESCAPE_REQUIRED_TEXT,
+            Options.Bar.value: sd.SOME_ESCAPE_REQUIRED_TEXT,
+        },
+        SOME_OPTION.value,
+    )
+
+    r_print(text)
+
+    assert (
+        f"{Options.Foo.value} - {sd.SOME_ESCAPE_REQUIRED_TEXT}\n"
+        f"{Options.Bar.value} - {sd.SOME_ESCAPE_REQUIRED_TEXT} (default)\n"
+    )

--- a/tests/_hyper_bump_it/sample_data.py
+++ b/tests/_hyper_bump_it/sample_data.py
@@ -116,6 +116,12 @@ SOME_NEW_LINE = "updated text"
 SOME_OTHER_NEW_LINE = "other updated text"
 SOME_WHITE_SPACE_OLD_LINE = "  start text with spaces on both side  "
 SOME_WHITE_SPACE_NEW_LINE = "  updated text with spaces on both side  "
+SOME_ESCAPE_REQUIRED_TEXT = (
+    "text that has a square brackets [v1.2.3] that need to be escaped"
+)
+SOME_OTHER_ESCAPE_REQUIRED_TEXT = (
+    "other text that has a square brackets [v1.2.3] that need to be escaped"
+)
 
 
 def some_git_actions(

--- a/tests/_hyper_bump_it/test_errors.py
+++ b/tests/_hyper_bump_it/test_errors.py
@@ -20,46 +20,94 @@ SOME_SUB_TABLES = ("some-name", "some-sub-name")
     [
         error.BumpItError(SOME_ERROR_MESSAGE),
         error.FormatKeyError(sd.SOME_SEARCH_FORMAT_PATTERN, SOME_VALID_KEYS),
+        error.FormatKeyError(sd.SOME_ESCAPE_REQUIRED_TEXT, SOME_VALID_KEYS),
         error.FormatPatternError(sd.SOME_SEARCH_FORMAT_PATTERN, SOME_ERROR_MESSAGE),
+        error.FormatPatternError(sd.SOME_ESCAPE_REQUIRED_TEXT, SOME_ERROR_MESSAGE),
         error.TodayFormatKeyError(sd.SOME_SEARCH_FORMAT_PATTERN, SOME_VALID_KEYS),
+        error.TodayFormatKeyError(sd.SOME_ESCAPE_REQUIRED_TEXT, SOME_VALID_KEYS),
         error.IncompleteKeystoneVersionError(
             Path(sd.SOME_GLOB_MATCHED_FILE_NAME), sd.SOME_SEARCH_FORMAT_PATTERN
         ),
+        error.IncompleteKeystoneVersionError(
+            Path(sd.SOME_ESCAPE_REQUIRED_TEXT), sd.SOME_ESCAPE_REQUIRED_TEXT
+        ),
         error.FileGlobError(Path(sd.SOME_DIRECTORY_NAME), sd.SOME_FILE_GLOB),
+        error.FileGlobError(
+            Path(sd.SOME_ESCAPE_REQUIRED_TEXT), sd.SOME_ESCAPE_REQUIRED_TEXT
+        ),
         error.KeystoneFileGlobError(sd.SOME_FILE_GLOB, []),
         error.KeystoneFileGlobError(
             sd.SOME_FILE_GLOB,
             [sd.SOME_GLOB_MATCHED_FILE_NAME, sd.SOME_OTHER_GLOB_MATCHED_FILE_NAME],
         ),
+        error.KeystoneFileGlobError(
+            sd.SOME_ESCAPE_REQUIRED_TEXT,
+            [sd.SOME_ESCAPE_REQUIRED_TEXT, sd.SOME_OTHER_GLOB_MATCHED_FILE_NAME],
+        ),
         error.VersionNotFound(
             Path(sd.SOME_DIRECTORY_NAME), sd.SOME_SEARCH_FORMAT_PATTERN
         ),
+        error.VersionNotFound(
+            Path(sd.SOME_ESCAPE_REQUIRED_TEXT), sd.SOME_ESCAPE_REQUIRED_TEXT
+        ),
         error.NoRepositoryError(Path(sd.SOME_DIRECTORY_NAME)),
+        error.NoRepositoryError(Path(sd.SOME_ESCAPE_REQUIRED_TEXT)),
         error.EmptyRepositoryError(Path(sd.SOME_DIRECTORY_NAME)),
+        error.EmptyRepositoryError(Path(sd.SOME_ESCAPE_REQUIRED_TEXT)),
         error.DirtyRepositoryError(Path(sd.SOME_DIRECTORY_NAME)),
+        error.DirtyRepositoryError(Path(sd.SOME_ESCAPE_REQUIRED_TEXT)),
         error.DetachedRepositoryError(Path(sd.SOME_DIRECTORY_NAME)),
+        error.DetachedRepositoryError(Path(sd.SOME_ESCAPE_REQUIRED_TEXT)),
         error.MissingRemoteError(sd.SOME_REMOTE, Path(sd.SOME_DIRECTORY_NAME)),
+        error.MissingRemoteError(
+            sd.SOME_ESCAPE_REQUIRED_TEXT, Path(sd.SOME_ESCAPE_REQUIRED_TEXT)
+        ),
         error.DisallowedInitialBranchError(
             frozenset({sd.SOME_ALLOWED_BRANCH}),
             sd.SOME_BRANCH,
             Path(sd.SOME_DIRECTORY_NAME),
         ),
         error.DisallowedInitialBranchError(
+            frozenset({sd.SOME_ESCAPE_REQUIRED_TEXT}),
+            sd.SOME_ESCAPE_REQUIRED_TEXT,
+            Path(sd.SOME_ESCAPE_REQUIRED_TEXT),
+        ),
+        error.DisallowedInitialBranchError(
             frozenset({sd.SOME_ALLOWED_BRANCH, sd.SOME_OTHER_ALLOWED_BRANCH}),
             sd.SOME_BRANCH,
             Path(sd.SOME_DIRECTORY_NAME),
         ),
+        error.DisallowedInitialBranchError(
+            frozenset({sd.SOME_ESCAPE_REQUIRED_TEXT, sd.SOME_OTHER_ALLOWED_BRANCH}),
+            sd.SOME_ESCAPE_REQUIRED_TEXT,
+            Path(sd.SOME_ESCAPE_REQUIRED_TEXT),
+        ),
         error.AlreadyExistsError(
             SOME_REF_TYPE, sd.SOME_BRANCH, Path(sd.SOME_DIRECTORY_NAME)
         ),
+        error.AlreadyExistsError(
+            SOME_REF_TYPE,
+            sd.SOME_ESCAPE_REQUIRED_TEXT,
+            Path(sd.SOME_ESCAPE_REQUIRED_TEXT),
+        ),
         error.ConfigurationFileNotFoundError(Path(sd.SOME_DIRECTORY_NAME)),
+        error.ConfigurationFileNotFoundError(Path(sd.SOME_ESCAPE_REQUIRED_TEXT)),
         error.ConfigurationFileReadError(
             Path(sd.SOME_CONFIG_FILE_NAME), Exception(SOME_ERROR_MESSAGE)
+        ),
+        error.ConfigurationFileReadError(
+            Path(sd.SOME_ESCAPE_REQUIRED_TEXT), Exception(sd.SOME_ESCAPE_REQUIRED_TEXT)
         ),
         error.ConfigurationFileWriteError(
             Path(sd.SOME_CONFIG_FILE_NAME), Exception(SOME_ERROR_MESSAGE)
         ),
+        error.ConfigurationFileWriteError(
+            Path(sd.SOME_ESCAPE_REQUIRED_TEXT), Exception(sd.SOME_ESCAPE_REQUIRED_TEXT)
+        ),
         error.SubTableNotExistError(Path(sd.SOME_CONFIG_FILE_NAME), SOME_SUB_TABLES),
+        error.SubTableNotExistError(
+            Path(sd.SOME_ESCAPE_REQUIRED_TEXT), SOME_SUB_TABLES
+        ),
     ],
 )
 def test_errors__rich_output__equivalent_to_str_representation(
@@ -177,6 +225,26 @@ def test_invalid_configuration_error__rich_output__expected_text(
     r_print(exception)
 
     rich_content = capture_rich.getvalue()
+    assert expected_content == rich_content
+
+
+def test_invalid_configuration_error__rich_output_escape_required__expected_text(
+    capture_rich: StringIO,
+):
+    validation_error = _some_validation_error({"foo": 1})
+    exception = error.InvalidConfigurationError(
+        Path(sd.SOME_ESCAPE_REQUIRED_TEXT), validation_error
+    )
+
+    r_print(exception)
+
+    rich_content = capture_rich.getvalue()
+    expected_content = (
+        f"The configuration file ({sd.SOME_ESCAPE_REQUIRED_TEXT}) is not valid:\n"
+        "1 validation error for SomeModel\n"
+        "bar\n"
+        "  field required\n"
+    )
     assert expected_content == rich_content
 
 


### PR DESCRIPTION
`Text` class accepts the style separately. So explicit escaping is not needed in those cases. To keep this change small, `Text` was not introduces in places it was not currently being used.

Fixes #123