### PR TITLE
Use codecov token in CI pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,6 +143,7 @@ jobs:
           with:
             file: coverage-${{ matrix.python-version }}.xml
             fail_ci_if_error: true
+            token: ${{ secrets.CODECOV_TOKEN }}
 
   verify-wheel:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This should resolve the intermittent upload errors that have been occurring at an increased rate recently. (See codecov/codecov-action#903)