### PR TITLE
Adjust Keystone file parsing to work with multiline search patterns

### DIFF
--- a/hyper_bump_it/_hyper_bump_it/config/keystone_parser.py
+++ b/hyper_bump_it/_hyper_bump_it/config/keystone_parser.py
@@ -91,12 +91,11 @@ def find_current_version(
     :raises VersionNotFound: None of the lines in the file matched the search pattern.
     """
     matching_pattern = _create_matching_pattern(search_pattern)
-    for i, line in enumerate(file.read_text().splitlines()):
-        if (match := matching_pattern.search(line)) is not None:
-            version_string = _version_string_from_match(match)
-            if version_string is None:
-                raise IncompleteKeystoneVersionError(file, search_pattern)
-            return Version.parse(version_string)
+    if (match := matching_pattern.search(file.read_text())) is not None:
+        version_string = _version_string_from_match(match)
+        if version_string is None:
+            raise IncompleteKeystoneVersionError(file, search_pattern)
+        return Version.parse(version_string)
 
     raise VersionNotFound(file, search_pattern)
 

--- a/tests/_hyper_bump_it/config/test_keystone_parser.py
+++ b/tests/_hyper_bump_it/config/test_keystone_parser.py
@@ -310,6 +310,18 @@ def test_format__invalid_key__error():
             Version.parse("1.2.3-p+a"),
             "11.22.33-pp+aa 1.2.3-p+a",
         ),
+        (
+            "multiline pattern - extra specific",
+            f"edf\n{{{keys.VERSION}}}",
+            Version.parse("1.2.3-p+a"),
+            "abc\n11.22.33-pp+aa\nedf\n1.2.3-p+a\n",
+        ),
+        (
+            "multiline pattern - values split",
+            f"{{{keys.CURRENT_MAJOR}}}.{{{keys.CURRENT_MINOR}}}\n{{{keys.CURRENT_PATCH}}}",
+            Version.parse("1.2.3"),
+            "1.2\n3",
+        ),
     ],
 )
 def test_find_current_version__valid_pattern_match__found(


### PR DESCRIPTION
Was missed during the implementation of #161 