### PR TITLE
A few small extra search date changes

### DIFF
--- a/docs/why-hyper-bump-it.md
+++ b/docs/why-hyper-bump-it.md
@@ -53,6 +53,16 @@ multiple lines of text as part of the update.
 
 `tbump` does not have support for this feature.
 
+### Date Support
+
+`hyper-bump-it` and `bump2version` support including date information in the search and replacement
+text. However, `bump2version` will always use the current date when looking in a file for a match.
+This means `bump2version` is not able to update text containing an older date. In contrast, when
+`hyper-bump-it` can match on arbitrary dates as part of the search text.
+
+
+`tbump` does not have support for this feature.
+
 ### Mercurial Support
 
 `bump2version` can work with projects that use Mercurial or Git.
@@ -69,16 +79,17 @@ mean that every file must contain the full version (see [Format Patterns][format
 
 ## Table of Differences
 
-| Feature                                  | hyper-bump-it | bump2version | tbump         |
-|------------------------------------------|---------------|--------------|---------------|
-| [VCS Branching][branching]               | Yes           | No           | No            |
-| [VCS Push][pushing]                      | Yes (opt-in)  | No           | Yes (opt-out) |
-| [Current Version from File][keystone]    | Yes           | No           | No            |
-| [Configuration File Format][config-file] | TOML          | INI          | TOML          |
-| [Multiline Search & Replace][multiline]  | Yes           | Yes          | No            |
-| Git                                      | Yes           | Yes          | Yes           |
-| Mercurial                                | No            | Yes          | No            |
-| [Custom Version Schemes][version-scheme] | No            | Yes          | Yes           |
+| Feature                                  | hyper-bump-it | bump2version          | tbump         |
+|------------------------------------------|---------------|-----------------------|---------------|
+| [VCS Branching][branching]               | Yes           | No                    | No            |
+| [VCS Push][pushing]                      | Yes (opt-in)  | No                    | Yes (opt-out) |
+| [Current Version from File][keystone]    | Yes           | No                    | No            |
+| [Configuration File Format][config-file] | TOML          | INI                   | TOML          |
+| [Multiline Search & Replace][multiline]  | Yes           | Yes                   | No            |
+| [Date Support][dates]                    | Yes           | Partial (exact match) | No            |
+| Git                                      | Yes           | Yes                   | Yes           |
+| Mercurial                                | No            | Yes                   | No            |
+| [Custom Version Schemes][version-scheme] | No            | Yes                   | Yes           |
 
 [^1]:
     As of the writing of this page (2023-02-20).
@@ -98,4 +109,5 @@ mean that every file must contain the full version (see [Format Patterns][format
 [keystone]: #current-version-from-file
 [config-file]: #toml-configuration-file
 [multiline]: #multiline-search--replacement-patterns
+[dates]: #date-support
 [version-scheme]: #custom-version-schemes

--- a/hyper_bump_it/_hyper_bump_it/error.py
+++ b/hyper_bump_it/_hyper_bump_it/error.py
@@ -183,6 +183,23 @@ class KeystoneFileGlobError(KeystoneError):
         return message
 
 
+class SearchTextNotFound(KeystoneError):
+    def __init__(self, file: Path, search_pattern: str) -> None:
+        self.file = file
+        self.search_pattern = search_pattern
+        super().__init__(
+            f"The search pattern '{self.search_pattern}' was not found in file '{self.file}'"
+        )
+
+    def __rich__(self) -> Text:
+        message = Text("The search pattern '")
+        message.append(self.search_pattern, style="format.pattern")
+        message.append("' was not found in file '")
+        message.append(str(self.file), style="file.path")
+        message.append("'")
+        return message
+
+
 class VersionNotFound(KeystoneError):
     def __init__(self, file: Path, search_pattern: str) -> None:
         self.file = file

--- a/hyper_bump_it/_hyper_bump_it/files.py
+++ b/hyper_bump_it/_hyper_bump_it/files.py
@@ -58,8 +58,8 @@ def _planned_change_for(
             search_text_maybe, file_text, replace_text
         )
     else:
+        no_replacement = search_text_maybe not in file_text
         updated_text = file_text.replace(search_text_maybe, replace_text)
-        no_replacement = updated_text == file_text
 
     if no_replacement:
         raise VersionNotFound(file.relative_to(project_root), search_pattern)

--- a/hyper_bump_it/_hyper_bump_it/files.py
+++ b/hyper_bump_it/_hyper_bump_it/files.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from . import format_pattern
 from .config import File
-from .error import FileGlobError, VersionNotFound
+from .error import FileGlobError, SearchTextNotFound
 from .format_pattern import FormatContext, TextFormatter, keys
 from .planned_changes import PlannedChange
 
@@ -22,7 +22,7 @@ def collect_planned_changes(
     :param formatter: Object that converts format patterns into text.
     :return: Descriptions of the change that would occur.
     :raises FileGlobError: Glob pattern for selecting files did not find any files.
-    :raises VersionNotFound: A file did not contain the produced search text.
+    :raises SearchTextNotFound: A file did not contain the produced search text.
     """
     changes = [
         _planned_change_for(
@@ -62,7 +62,7 @@ def _planned_change_for(
         updated_text = file_text.replace(search_text_maybe, replace_text)
 
     if no_replacement:
-        raise VersionNotFound(file.relative_to(project_root), search_pattern)
+        raise SearchTextNotFound(file.relative_to(project_root), search_pattern)
 
     return PlannedChange(
         file,

--- a/tests/_hyper_bump_it/test_errors.py
+++ b/tests/_hyper_bump_it/test_errors.py
@@ -46,6 +46,9 @@ SOME_SUB_TABLES = ("some-name", "some-sub-name")
         error.VersionNotFound(
             Path(sd.SOME_DIRECTORY_NAME), sd.SOME_SEARCH_FORMAT_PATTERN
         ),
+        error.SearchTextNotFound(
+            Path(sd.SOME_DIRECTORY_NAME), sd.SOME_SEARCH_FORMAT_PATTERN
+        ),
         error.VersionNotFound(
             Path(sd.SOME_ESCAPE_REQUIRED_TEXT), sd.SOME_ESCAPE_REQUIRED_TEXT
         ),

--- a/tests/_hyper_bump_it/test_files.py
+++ b/tests/_hyper_bump_it/test_files.py
@@ -7,7 +7,7 @@ import pytest
 from freezegun.api import FrozenDateTimeFactory
 
 from hyper_bump_it._hyper_bump_it import files
-from hyper_bump_it._hyper_bump_it.error import FileGlobError, VersionNotFound
+from hyper_bump_it._hyper_bump_it.error import FileGlobError, SearchTextNotFound
 from hyper_bump_it._hyper_bump_it.files import PlannedChange
 from hyper_bump_it._hyper_bump_it.format_pattern import keys
 from tests._hyper_bump_it import sample_data as sd
@@ -315,7 +315,7 @@ def test_collect_planned_changes__version_not_found__error(tmp_path: Path):
     some_file = tmp_path / SOME_FILE_NAME
     some_file.write_text("")
 
-    with pytest.raises(VersionNotFound):
+    with pytest.raises(SearchTextNotFound):
         files.collect_planned_changes(
             tmp_path,
             sd.some_file(some_file.name),

--- a/tests/_hyper_bump_it/test_files.py
+++ b/tests/_hyper_bump_it/test_files.py
@@ -290,6 +290,27 @@ def test_collect_planned_changes__includes_today__matches_any_date(
     assert changes[0].new_content == expected_text
 
 
+def test_collect_planned_changes__replace_matches_search__planned_change_returned(
+    tmp_path: Path,
+):
+    original_text = f"ab {sd.SOME_DATE} cd"
+    some_file = tmp_path / SOME_FILE_NAME
+    some_file.write_text(original_text)
+
+    changes = files.collect_planned_changes(
+        tmp_path,
+        sd.some_file(
+            "*.txt",
+            search_format_pattern=f"{{{keys.TODAY}}}",
+            replace_format_pattern=f"{{{keys.TODAY}}}",
+        ),
+        formatter=sd.some_text_formatter(today=sd.SOME_DATE),
+    )
+
+    assert len(changes) == 1
+    assert changes[0].new_content == original_text
+
+
 def test_collect_planned_changes__version_not_found__error(tmp_path: Path):
     some_file = tmp_path / SOME_FILE_NAME
     some_file.write_text("")


### PR DESCRIPTION
Additional to #169 

* Include date support in tool comparison
* Search pattern isn't guaranteed to have the version (More generic error message)
* Don't error is replace text matches search text (If the search text is found, treat it as a valid change.)
