### PR TITLE
Bump version: 0.4.1 → 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.5.0] - 2023-08-04
 
+
 ### Added
 
 * Support for signing commits and tags.


### PR DESCRIPTION
Fake bump to retry automated release

Actual version bump in #283  