### PR TITLE
Use given search format pattern when prompting for replace pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Warning before replacing an existing configuration with project initialization.
+* Interactive project initialization more clearly describes explict replace format pattern.
+* Interactive project initialization now shows recently provided search pattern when addressing
+    issues with a file definition that omitted the replace format pattern.
 * Update development status classifier.
 
 ## [0.5.0] - 2023-08-04

--- a/tests/_hyper_bump_it/cli/interactive/test_files.py
+++ b/tests/_hyper_bump_it/cli/interactive/test_files.py
@@ -606,3 +606,84 @@ def test_configure__replace_slash_n_pattern__convert_to_multiline_pattern(
         )
     ]
     assert result_has_keystone is False
+
+
+def test_configure__add_invalid_search_omit_replace__replace_prompts_with_new_search(
+    force_input: ForceInput, capture_rich: StringIO
+):
+    force_input(
+        FilesMenu.Add.value,
+        sd.SOME_OTHER_FILE_GLOB,
+        sd.SOME_INVALID_FORMAT_PATTERN,
+        "y",  # yes, omit replace format pattern
+        "n",  # no, keystone
+        # start again
+        sd.SOME_OTHER_FILE_GLOB,
+        sd.SOME_SEARCH_FORMAT_PATTERN,
+        "n",  # no, explicit replace format pattern
+        sd.SOME_REPLACE_FORMAT_PATTERN,
+        "n",  # no, keystone
+        force_input.NO_INPUT,
+    )
+    editor = files.FilesConfigEditor(
+        [sd.some_file_definition()], create_invalid_first()
+    )
+
+    editor.configure()
+
+    assert (
+        f"There currently is no replace format pattern. The current search pattern is '{sd.SOME_SEARCH_FORMAT_PATTERN}'."
+        in capture_rich.getvalue()
+    )
+
+
+def test_configure__add_search_no_omit_replace__replace_prompts_with_search(
+    force_input: ForceInput, capture_rich: StringIO
+):
+    force_input(
+        FilesMenu.Add.value,
+        sd.SOME_OTHER_FILE_GLOB,
+        sd.SOME_SEARCH_FORMAT_PATTERN,
+        "n",  # no, explicit replace format pattern
+        sd.SOME_REPLACE_FORMAT_PATTERN,
+        "n",  # no, keystone
+        force_input.NO_INPUT,
+    )
+    editor = files.FilesConfigEditor([sd.some_file_definition()], ALWAYS_VALID)
+
+    editor.configure()
+
+    assert (
+        f"There currently is no replace format pattern. The current search pattern is '{sd.SOME_SEARCH_FORMAT_PATTERN}'."
+        in capture_rich.getvalue()
+    )
+
+
+def test_configure__replace_invalid__again_replace_prompts_with_previous_replace(
+    force_input: ForceInput, capture_rich: StringIO
+):
+    force_input(
+        FilesMenu.Add.value,
+        sd.SOME_OTHER_FILE_GLOB,
+        sd.SOME_SEARCH_FORMAT_PATTERN,
+        "n",  # no, explicit replace format pattern
+        sd.SOME_INVALID_FORMAT_PATTERN,
+        "n",  # no, keystone
+        # start again
+        sd.SOME_OTHER_FILE_GLOB,
+        sd.SOME_SEARCH_FORMAT_PATTERN,
+        "n",  # no, explicit replace format pattern
+        sd.SOME_REPLACE_FORMAT_PATTERN,
+        "n",  # no, keystone
+        force_input.NO_INPUT,
+    )
+    editor = files.FilesConfigEditor(
+        [sd.some_file_definition()], create_invalid_first()
+    )
+
+    editor.configure()
+
+    assert (
+        f"The current replace format pattern is '{sd.SOME_INVALID_FORMAT_PATTERN}'."
+        in capture_rich.getvalue()
+    )


### PR DESCRIPTION
Also, more clearly explain default of using search pattern explicitly.

Fixes #148 