### PR TITLE
Use docker compose instead of docker-compose

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -167,7 +167,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Build devbox image
-        run: docker-compose build devbox
+        run: docker compose build devbox
 
   build-docs:
     runs-on: ubuntu-latest

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -87,7 +87,7 @@ images that is isolated from the host machine. The Docker documentation has deta
 Once that is configured, it is possible to execute code in the container:
 
 ```bash
-docker-compose run --rm devbox
+docker compose run --rm devbox
 (custom code here)
 ```
 
@@ -110,7 +110,7 @@ when run locally, `black` and `isort` are configured to automatically correct is
     Since this is so common, there is also a shorthand for running this in the container
 
     ```bash
-    docker-compose run --rm check
+    docker compose run --rm check
     ```
 
 ### Writing Tests


### PR DESCRIPTION
GitHub is rolling out runners that no longer have `docker-compose`.