### PR TITLE
Loosen expected output for failure test case

### DIFF
--- a/tests/_hyper_bump_it/cli/test_by.py
+++ b/tests/_hyper_bump_it/cli/test_by.py
@@ -23,7 +23,7 @@ from tests._hyper_bump_it.cli.common import (
         ([sd.SOME_VERSION_STRING], r"Invalid value for 'PART_TO_BUMP"),
         (
             [sd.SOME_BUMP_PART.value, "--current-version", "1"],
-            r"Invalid value for '--current-version': .+?",
+            r"Invalid value for '--current-version'",
         ),
         (
             [sd.SOME_BUMP_PART.value, "--commit", sd.SOME_NON_GIT_ACTION_STRING],

--- a/tests/_hyper_bump_it/cli/test_to.py
+++ b/tests/_hyper_bump_it/cli/test_to.py
@@ -27,7 +27,7 @@ from tests._hyper_bump_it.cli.common import (
         ),
         (
             [sd.SOME_VERSION_STRING, "--current-version", "1"],
-            r"Invalid value for '--current-version': .+?",
+            r"Invalid value for '--current-version'",
         ),
         (
             [sd.SOME_VERSION_STRING, "--commit", sd.SOME_NON_GIT_ACTION_STRING],


### PR DESCRIPTION
A change to `click` caused the output to change (thought I think this is the result of a bug pallets/click#2971). However the specifics of the error output are not the significant part of the test cases. So change them to pass for the current and previous output.