### PR TITLE
Migrate to ruff and uv for linting and package installation

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,2 +1,0 @@
-[bandit]
-exclude: *venv*,*env*,*scratch*,./tests

--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,0 @@
-[flake8]
-max-line-length = 88
-max-complexity = 8
-extend-ignore = W503, E501, E704
-builtins = unicode
-tee = True
-exclude = venv,env,.venv,scratch

--- a/.github/actions/initialize-hatch/action.yml
+++ b/.github/actions/initialize-hatch/action.yml
@@ -1,5 +1,5 @@
 name: "Initialize Hatch"
-description: "Install hatch & create an environment"
+description: "Install hatch & uv, then create an environment"
 inputs:
   environment-name:
     description: "Which environment to create"
@@ -12,7 +12,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: "Install hatch"
+    - name: "Install hatch and uv"
       run: "pip install -r requirements-bootstrap.txt"
       shell: "bash"
     - name: "Create environment"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,21 +14,7 @@ env:
   PYTHON_VERSION: "3.14"
 
 jobs:
-  bandit:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-      - name: Initialize Hatch
-        uses: ./.github/actions/initialize-hatch
-
-      - name: Run bandit
-        run: hatch run bandit-ci
-
-  black:
+  ruff:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -40,36 +26,11 @@ jobs:
       - name: Initialize Hatch
         uses: ./.github/actions/initialize-hatch
 
-      - name: Run black
-        run: hatch run black-check
+      - name: Run ruff linter
+        run: hatch run ruff-check
 
-  flake8:
-    runs-on: ubuntu-latest
-    steps:
-        - name: Check out code
-          uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-          with:
-            python-version: ${{ env.PYTHON_VERSION }}
-        - name: Initialize Hatch
-          uses: ./.github/actions/initialize-hatch
-
-        - name: Run flake8
-          run: hatch run flake8-check
-
-  isort:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-      - name: Initialize Hatch
-        uses: ./.github/actions/initialize-hatch
-
-      - name: Run isort
-        run: hatch run isort-check
+      - name: Run ruff formatter
+        run: hatch run ruff-format-check
 
   mypy:
     runs-on: ubuntu-latest

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3.4'
-
 services:
 
   # a fully loaded development environment to test new code
@@ -12,7 +10,7 @@ services:
       - ./:/app
 
   # run all the tests and linting locally
-  # - black & isort will format code to address issues
+  # - ruff will format code to address issues
   check:
     <<: *devbox
     command: ["hatch", "run", "check"]
@@ -28,4 +26,3 @@ services:
   mike:
     <<: *mkdocs
     entrypoint: ["hatch", "run", "docs:mike"]
-

--- a/docker/devbox.dockerfile
+++ b/docker/devbox.dockerfile
@@ -1,19 +1,24 @@
-FROM python:3.12-bookworm@sha256:8c284a84bc273b858725193c1ea53192aa8cad6ca0ce3fd90b4abcfcd3cef915
+FROM python:3.14-bookworm
 
 ARG _USER="hyper_bump_it"
 ARG _UID="1000"
 ARG _GID="100"
 ARG _SHELL="/bin/bash"
 
+# Install uv system-wide for hatch to use as installer
+ENV UV_NO_CACHE="true"
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
+    cp /root/.local/bin/uv /usr/local/bin/uv && \
+    cp /root/.local/bin/uvx /usr/local/bin/uvx
 
 RUN useradd -m -s "${_SHELL}" -N -u "${_UID}" "${_USER}"
 
-ENV USER ${_USER}
-ENV UID ${_UID}
-ENV GID ${_GID}
-ENV HOME /home/${_USER}
-ENV PATH "${HOME}/.local/bin/:${PATH}"
-ENV PIP_NO_CACHE_DIR "true"
+ENV USER=${_USER}
+ENV UID=${_UID}
+ENV GID=${_GID}
+ENV HOME=/home/${_USER}
+ENV PATH="${HOME}/.local/bin/:${PATH}"
+ENV PIP_NO_CACHE_DIR="true"
 
 
 RUN mkdir /app && chown ${UID}:${GID} /app
@@ -23,7 +28,7 @@ USER ${_USER}
 RUN git config --global user.name "TESTING-${_USER}" && \
     git config --global user.email "TESTING-${_USER}@example.com"
 
-# Create a signing certificate to use for testing. Once the certificate exipires, the image will
+# Create a signing certificate to use for testing. Once the certificate expires, the image will
 # need to be rebuilt.
 RUN gpg --quick-generate-key --batch --passphrase '' "TESTING-${_USER} <TESTING-${_USER}@example.com>" default sign 3m
 

--- a/hyper_bump_it/_hyper_bump_it/cli/by.py
+++ b/hyper_bump_it/_hyper_bump_it/cli/by.py
@@ -3,7 +3,7 @@ Bump version by part command.
 """
 
 from pathlib import Path
-from typing import Annotated, Optional
+from typing import Annotated
 
 import typer
 
@@ -19,38 +19,34 @@ def by_command(
         typer.Argument(..., help="Part of version to increment", show_default=False),
     ],
     config_file: Annotated[
-        Optional[Path], common.CONFIG_FILE
+        Path | None, common.CONFIG_FILE
     ] = common.CONFIG_FILE_DEFAULT,
     project_root: Annotated[Path, common.PROJECT_ROOT] = common.PROJECT_ROOT_DEFAULT,
     dry_run: Annotated[bool, common.DRY_RUN] = common.DRY_RUN_DEFAULT,
     patch: Annotated[bool, common.PATCH] = common.PATCH_DEFAULT,
     skip_confirm_prompt: Annotated[
-        Optional[bool], common.SKIP_CONFIRM_PROMPT
+        bool | None, common.SKIP_CONFIRM_PROMPT
     ] = common.SKIP_CONFIRM_PROMPT_DEFAULT,
     current_version: Annotated[
-        Optional[Version], common.CURRENT_VERSION
+        Version | None, common.CURRENT_VERSION
     ] = common.CURRENT_VERSION_DEFAULT,
-    commit: Annotated[Optional[GitAction], common.commit()] = None,
-    branch: Annotated[Optional[GitAction], common.branch()] = None,
-    tag: Annotated[Optional[GitAction], common.tag()] = None,
-    remote: Annotated[Optional[str], common.remote()] = None,
-    commit_format_pattern: Annotated[
-        Optional[str], common.commit_format_pattern()
-    ] = None,
-    branch_format_pattern: Annotated[
-        Optional[str], common.branch_format_pattern()
-    ] = None,
+    commit: Annotated[GitAction | None, common.commit()] = None,
+    branch: Annotated[GitAction | None, common.branch()] = None,
+    tag: Annotated[GitAction | None, common.tag()] = None,
+    remote: Annotated[str | None, common.remote()] = None,
+    commit_format_pattern: Annotated[str | None, common.commit_format_pattern()] = None,
+    branch_format_pattern: Annotated[str | None, common.branch_format_pattern()] = None,
     tag_name_format_pattern: Annotated[
-        Optional[str], common.tag_name_format_pattern()
+        str | None, common.tag_name_format_pattern()
     ] = None,
     tag_message_format_pattern: Annotated[
-        Optional[str], common.tag_message_format_pattern()
+        str | None, common.tag_message_format_pattern()
     ] = None,
     allowed_init_branch: Annotated[
-        Optional[list[str]], common.allowed_init_branch()
+        list[str] | None, common.allowed_init_branch()
     ] = None,
     allow_any_init_branch: Annotated[
-        Optional[bool], common.allow_any_init_branch()
+        bool | None, common.allow_any_init_branch()
     ] = None,
 ) -> None:
     """

--- a/hyper_bump_it/_hyper_bump_it/cli/common.py
+++ b/hyper_bump_it/_hyper_bump_it/cli/common.py
@@ -2,9 +2,10 @@
 Common command line functionality.
 """
 
+from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Iterator, NoReturn, Optional, Protocol, overload
+from typing import Any, NoReturn, Protocol, overload
 
 import typer
 from rich.align import AlignMethod
@@ -43,7 +44,7 @@ CONFIG_FILE = typer.Option(
     help="Path to dedicated configuration file to use instead of normal file discovery",
     show_default=False,
 )
-CONFIG_FILE_DEFAULT: Optional[Path] = None
+CONFIG_FILE_DEFAULT: Path | None = None
 PROJECT_ROOT = typer.Option(
     help="Path to directory containing the project",
     show_default="Use current directory",
@@ -70,14 +71,14 @@ SKIP_CONFIRM_PROMPT = typer.Option(
     help="Answer yes to the confirmation prompt and run non-interactively",
     show_default=False,
 )
-SKIP_CONFIRM_PROMPT_DEFAULT: Optional[bool] = None
+SKIP_CONFIRM_PROMPT_DEFAULT: bool | None = None
 CURRENT_VERSION = typer.Option(
     help="Override the current version",
     show_default=False,
     rich_help_panel=OVERRIDE_PANEL_NAME,
     parser=Version.parse,
 )
-CURRENT_VERSION_DEFAULT: Optional[Version] = None
+CURRENT_VERSION_DEFAULT: Version | None = None
 
 commit = _create_option_factory("Control commit Git action")
 branch = _create_option_factory("Control branch Git action")
@@ -103,9 +104,9 @@ allow_any_init_branch = _create_option_factory(
 
 
 def allowed_init_branches(
-    allowed_branches_arg: Optional[list[str]],
-    allow_any_init_branch_arg: Optional[bool],
-) -> Optional[frozenset[str]]:
+    allowed_branches_arg: list[str] | None,
+    allow_any_init_branch_arg: bool | None,
+) -> frozenset[str] | None:
     if allow_any_init_branch_arg is True:
         return frozenset()
     if allowed_branches_arg is None or len(allowed_branches_arg) == 0:
@@ -146,8 +147,8 @@ def resolve(path: Path) -> Path: ...
 
 
 @overload
-def resolve(path: Optional[Path]) -> Optional[Path]: ...
+def resolve(path: Path | None) -> Path | None: ...
 
 
-def resolve(path: Optional[Path]) -> Optional[Path]:
+def resolve(path: Path | None) -> Path | None:
     return None if path is None else path.resolve()

--- a/hyper_bump_it/_hyper_bump_it/cli/init.py
+++ b/hyper_bump_it/_hyper_bump_it/cli/init.py
@@ -2,8 +2,9 @@
 Initialize configuration command.
 """
 
+from collections.abc import Mapping
 from pathlib import Path
-from typing import Annotated, Mapping
+from typing import Annotated
 
 import tomlkit
 import typer

--- a/hyper_bump_it/_hyper_bump_it/cli/interactive/file_validation.py
+++ b/hyper_bump_it/_hyper_bump_it/cli/interactive/file_validation.py
@@ -5,7 +5,6 @@ Validate a file definition to see if it could be used for a specific project.
 from dataclasses import dataclass
 from enum import Enum, auto
 from pathlib import Path
-from typing import Optional
 
 from rich.text import Text
 
@@ -40,7 +39,7 @@ class DefinitionValidator:
             current_version=current_version, new_version=_FAKE_NEXT_VERSION
         )
 
-    def __call__(self, definition: FileDefinition) -> Optional[ValidationFailure]:
+    def __call__(self, definition: FileDefinition) -> ValidationFailure | None:
         matched_files = list(self._project_root.glob(definition.file_glob))
         if (
             result := self._validate_matched_files(
@@ -67,7 +66,7 @@ class DefinitionValidator:
 
     def _validate_matched_files(
         self, definition: FileDefinition, matched_files: list[Path], project_root: Path
-    ) -> Optional[ValidationFailure]:
+    ) -> ValidationFailure | None:
         if len(matched_files) == 0:
             return ValidationFailure(
                 FailureType.NoFiles,
@@ -104,7 +103,7 @@ class DefinitionValidator:
     @staticmethod
     def _check_file_contents(
         search_text: str, matched_files: list[Path]
-    ) -> Optional[ValidationFailure]:
+    ) -> ValidationFailure | None:
         for file in matched_files:
             if search_text not in file.read_text():
                 return ValidationFailure(

--- a/hyper_bump_it/_hyper_bump_it/cli/interactive/files.py
+++ b/hyper_bump_it/_hyper_bump_it/cli/interactive/files.py
@@ -3,7 +3,6 @@ Go through a series of prompts to construct a custom files configuration.
 """
 
 from enum import Enum
-from typing import Optional
 
 from rich.text import Text
 
@@ -105,7 +104,7 @@ def _prompt_file_menu() -> FilesMenu:
     )
 
 
-def _prompt_file_glob(default: Optional[str]) -> str:
+def _prompt_file_glob(default: str | None) -> str:
     if default is None:
         return ui.ask("Enter the glob pattern to match one or more files")
 
@@ -118,7 +117,7 @@ def _prompt_file_glob(default: Optional[str]) -> str:
 
 
 def _prompt_definition(
-    current: Optional[FileDefinition],
+    current: FileDefinition | None,
     has_keystone: bool,
     validator: DefinitionValidator,
 ) -> FileDefinition:
@@ -168,7 +167,7 @@ def _prompt_definition(
         current = definition
 
 
-def _keystone_selection(has_keystone: bool, current_keystone: Optional[bool]) -> bool:
+def _keystone_selection(has_keystone: bool, current_keystone: bool | None) -> bool:
     if has_keystone:
         if current_keystone:
             return _prompt_keystone(default=True)
@@ -214,8 +213,8 @@ def _prompt_search_format_pattern(current: str, new: bool) -> str:
 
 
 def _prompt_replace_format_pattern(
-    current: Optional[str], search_pattern: str
-) -> Optional[str]:
+    current: str | None, search_pattern: str
+) -> str | None:
     use_search_pattern = ui.confirm(
         "The replace format pattern can be omitted. In this case, the search format pattern value "
         "is used.\n"

--- a/hyper_bump_it/_hyper_bump_it/cli/interactive/git.py
+++ b/hyper_bump_it/_hyper_bump_it/cli/interactive/git.py
@@ -3,7 +3,7 @@ Go through a series of prompts to construct a custom Git integration configurati
 """
 
 from enum import Enum
-from typing import Optional, TypeVar, Union
+from typing import TypeVar
 
 from pydantic import ValidationError
 from rich.text import Text
@@ -119,7 +119,7 @@ class GitConfigEditor:
         ui.blank_line()
 
     def _store_update(
-        self, config_name: str, value: Union[Optional[str], frozenset[str]]
+        self, config_name: str, value: str | None | frozenset[str]
     ) -> None:
         if value is not None:
             self._config = self._config.model_copy(update={config_name: value})
@@ -182,7 +182,7 @@ def _prompt_git_menu() -> GitMenu:
     )
 
 
-def _prompt_remote(current_remote: str) -> Optional[str]:
+def _prompt_remote(current_remote: str) -> str | None:
     message = Text("When an action is set to '")
     message.append("create-and-push", style="vcs.action")
     message.append(
@@ -194,9 +194,7 @@ def _prompt_remote(current_remote: str) -> Optional[str]:
     return ui.ask(message, default=None)
 
 
-def _prompt_format_pattern(
-    name: str, current_pattern: str, default: str
-) -> Optional[str]:
+def _prompt_format_pattern(name: str, current_pattern: str, default: str) -> str | None:
     message = Text("Format patterns are used to generate text. ")
     message.append("The format pattern for ")
     message.append(name)
@@ -339,7 +337,7 @@ def _display_branch_list(config: frozenset[str]) -> None:
         ui.display(message)
 
 
-def _prompt_add_branch() -> Optional[str]:
+def _prompt_add_branch() -> str | None:
     return ui.ask(
         "Enter the name of the branch that will be allowed as the initial branch when executing",
     )

--- a/hyper_bump_it/_hyper_bump_it/cli/interactive/top_level.py
+++ b/hyper_bump_it/_hyper_bump_it/cli/interactive/top_level.py
@@ -4,7 +4,6 @@ Go through a series of prompts to construct a custom configuration.
 
 from enum import Enum
 from pathlib import Path
-from typing import Set
 
 from rich.text import Text
 
@@ -38,7 +37,7 @@ class InteractiveConfigEditor:
         self._config: ConfigFile = initial_config.model_copy(deep=True)
         self._pyproject = pyproject
         self._project_root = project_root
-        self._was_configured: Set[TopMenu] = set()
+        self._was_configured: set[TopMenu] = set()
         self._config_funcs = {
             TopMenu.General: self._configure_general,
             TopMenu.Files: self._configure_files,

--- a/hyper_bump_it/_hyper_bump_it/cli/to.py
+++ b/hyper_bump_it/_hyper_bump_it/cli/to.py
@@ -3,7 +3,7 @@ Bump to version command.
 """
 
 from pathlib import Path
-from typing import Annotated, Optional
+from typing import Annotated
 
 import typer
 
@@ -24,38 +24,34 @@ def to_command(
         ),
     ],
     config_file: Annotated[
-        Optional[Path], common.CONFIG_FILE
+        Path | None, common.CONFIG_FILE
     ] = common.CONFIG_FILE_DEFAULT,
     project_root: Annotated[Path, common.PROJECT_ROOT] = common.PROJECT_ROOT_DEFAULT,
     dry_run: Annotated[bool, common.DRY_RUN] = common.DRY_RUN_DEFAULT,
     patch: Annotated[bool, common.PATCH] = common.PATCH_DEFAULT,
     skip_confirm_prompt: Annotated[
-        Optional[bool], common.SKIP_CONFIRM_PROMPT
+        bool | None, common.SKIP_CONFIRM_PROMPT
     ] = common.SKIP_CONFIRM_PROMPT_DEFAULT,
     current_version: Annotated[
-        Optional[Version], common.CURRENT_VERSION
+        Version | None, common.CURRENT_VERSION
     ] = common.CURRENT_VERSION_DEFAULT,
-    commit: Annotated[Optional[GitAction], common.commit()] = None,
-    branch: Annotated[Optional[GitAction], common.branch()] = None,
-    tag: Annotated[Optional[GitAction], common.tag()] = None,
-    remote: Annotated[Optional[str], common.remote()] = None,
-    commit_format_pattern: Annotated[
-        Optional[str], common.commit_format_pattern()
-    ] = None,
-    branch_format_pattern: Annotated[
-        Optional[str], common.branch_format_pattern()
-    ] = None,
+    commit: Annotated[GitAction | None, common.commit()] = None,
+    branch: Annotated[GitAction | None, common.branch()] = None,
+    tag: Annotated[GitAction | None, common.tag()] = None,
+    remote: Annotated[str | None, common.remote()] = None,
+    commit_format_pattern: Annotated[str | None, common.commit_format_pattern()] = None,
+    branch_format_pattern: Annotated[str | None, common.branch_format_pattern()] = None,
     tag_name_format_pattern: Annotated[
-        Optional[str], common.tag_name_format_pattern()
+        str | None, common.tag_name_format_pattern()
     ] = None,
     tag_message_format_pattern: Annotated[
-        Optional[str], common.tag_message_format_pattern()
+        str | None, common.tag_message_format_pattern()
     ] = None,
     allowed_init_branch: Annotated[
-        Optional[list[str]], common.allowed_init_branch()
+        list[str] | None, common.allowed_init_branch()
     ] = None,
     allow_any_init_branch: Annotated[
-        Optional[bool], common.allow_any_init_branch()
+        bool | None, common.allow_any_init_branch()
     ] = None,
 ) -> None:
     """

--- a/hyper_bump_it/_hyper_bump_it/config/application.py
+++ b/hyper_bump_it/_hyper_bump_it/config/application.py
@@ -2,9 +2,10 @@
 Program configuration
 """
 
+from collections.abc import Callable
 from dataclasses import astuple, dataclass
 from pathlib import Path
-from typing import Callable, Optional, Union, cast
+from typing import cast
 
 from ..error import KeystoneFileGlobError
 from ..version import Version
@@ -61,7 +62,7 @@ class Config:
     dry_run: bool
     patch: bool
     show_confirm_prompt: bool
-    config_version_updater: Optional[file.ConfigVersionUpdater]
+    config_version_updater: file.ConfigVersionUpdater | None
 
     @property
     def no_execute_plan(self) -> bool:
@@ -135,7 +136,7 @@ def config_for_bump_by(args: BumpByArgs) -> Config:
 
 
 def _current_version(
-    args_version: Optional[Version], file_config: file.ConfigFile, project_root: Path
+    args_version: Version | None, file_config: file.ConfigFile, project_root: Path
 ) -> Version:
     if args_version is not None:
         return args_version
@@ -166,7 +167,7 @@ def _convert_files(config_files: list[file.File]) -> list[File]:
     ]
 
 
-def _convert_git(args: Union[BumpToArgs, BumpByArgs], git: file.Git) -> Git:
+def _convert_git(args: BumpToArgs | BumpByArgs, git: file.Git) -> Git:
     return Git(
         remote=args.remote or git.remote,
         commit_format_pattern=args.commit_format_pattern or git.commit_format_pattern,
@@ -189,7 +190,7 @@ def _convert_git(args: Union[BumpToArgs, BumpByArgs], git: file.Git) -> Git:
 
 
 def _merge_allowed_branches(
-    arg_branches: Optional[frozenset[str]],
+    arg_branches: frozenset[str] | None,
     file_branches: frozenset[str],
     file_extend_branches: frozenset[str],
 ) -> frozenset[str]:
@@ -199,7 +200,7 @@ def _merge_allowed_branches(
 
 
 def _show_confirm_prompt(
-    file_show_confirm: bool, cli_skip_confirm_prompt: Optional[bool]
+    file_show_confirm: bool, cli_skip_confirm_prompt: bool | None
 ) -> bool:
     return (
         file_show_confirm

--- a/hyper_bump_it/_hyper_bump_it/config/cli.py
+++ b/hyper_bump_it/_hyper_bump_it/config/cli.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Optional
 
 from ..version import Version
 from .core import GitAction
@@ -16,38 +15,38 @@ class BumpPart(str, Enum):
 @dataclass
 class BumpToArgs:
     new_version: Version
-    config_file: Optional[Path]  # absolute resolved path
+    config_file: Path | None  # absolute resolved path
     project_root: Path  # absolute resolved path
     dry_run: bool
     patch: bool
-    skip_confirm_prompt: Optional[bool]
-    current_version: Optional[Version]
-    commit: Optional[GitAction]
-    branch: Optional[GitAction]
-    tag: Optional[GitAction]
-    remote: Optional[str]
-    commit_format_pattern: Optional[str]
-    branch_format_pattern: Optional[str]
-    tag_name_format_pattern: Optional[str]
-    tag_message_format_pattern: Optional[str]
-    allowed_initial_branches: Optional[frozenset[str]]
+    skip_confirm_prompt: bool | None
+    current_version: Version | None
+    commit: GitAction | None
+    branch: GitAction | None
+    tag: GitAction | None
+    remote: str | None
+    commit_format_pattern: str | None
+    branch_format_pattern: str | None
+    tag_name_format_pattern: str | None
+    tag_message_format_pattern: str | None
+    allowed_initial_branches: frozenset[str] | None
 
 
 @dataclass
 class BumpByArgs:
     part_to_bump: BumpPart
-    config_file: Optional[Path]  # absolute resolved path
+    config_file: Path | None  # absolute resolved path
     project_root: Path  # absolute resolved path
     dry_run: bool
     patch: bool
-    skip_confirm_prompt: Optional[bool]
-    current_version: Optional[Version]
-    commit: Optional[GitAction]
-    branch: Optional[GitAction]
-    tag: Optional[GitAction]
-    remote: Optional[str]
-    commit_format_pattern: Optional[str]
-    branch_format_pattern: Optional[str]
-    tag_name_format_pattern: Optional[str]
-    tag_message_format_pattern: Optional[str]
-    allowed_initial_branches: Optional[frozenset[str]]
+    skip_confirm_prompt: bool | None
+    current_version: Version | None
+    commit: GitAction | None
+    branch: GitAction | None
+    tag: GitAction | None
+    remote: str | None
+    commit_format_pattern: str | None
+    branch_format_pattern: str | None
+    tag_name_format_pattern: str | None
+    tag_message_format_pattern: str | None
+    allowed_initial_branches: frozenset[str] | None

--- a/hyper_bump_it/_hyper_bump_it/config/file.py
+++ b/hyper_bump_it/_hyper_bump_it/config/file.py
@@ -1,6 +1,6 @@
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Annotated, Optional, TypeAlias, Union, cast
+from typing import Annotated, TypeAlias, cast
 
 import tomlkit
 from pydantic import (
@@ -51,7 +51,7 @@ class HyperBaseMode(BaseModel):
 
 
 def _check_action(
-    value: Optional[object], handler: ValidatorFunctionWrapHandler
+    value: object | None, handler: ValidatorFunctionWrapHandler
 ) -> GitAction:
     if isinstance(value, str):
         for action in GitAction:
@@ -80,7 +80,7 @@ class GitActions(HyperBaseMode):
 
 
 def _check_branches(
-    value: Optional[object], handler: ValidatorFunctionWrapHandler
+    value: object | None, handler: ValidatorFunctionWrapHandler
 ) -> frozenset[str]:
     if isinstance(value, list):
         value = frozenset(value)
@@ -105,21 +105,21 @@ class File(HyperBaseMode):
     file_glob: str  # relative to project root directory
     keystone: bool = False
     search_format_pattern: str = DEFAULT_SEARCH_PATTERN
-    replace_format_pattern: Optional[str] = None
+    replace_format_pattern: str | None = None
 
 
-HyperConfigFileValues: TypeAlias = dict[str, Union[list[File], Optional[str], Git]]
+HyperConfigFileValues: TypeAlias = dict[str, list[File] | str | None | Git]
 
 
 def _check_version(
-    value: Optional[object], handler: ValidatorFunctionWrapHandler
-) -> Optional[Version]:
+    value: object | None, handler: ValidatorFunctionWrapHandler
+) -> Version | None:
     if isinstance(value, str):
         return Version.parse(value)
     return cast(Version, handler(value))
 
 
-OptionalVersion = Annotated[Optional[Version], WrapValidator(_check_version)]
+OptionalVersion = Annotated[Version | None, WrapValidator(_check_version)]
 
 
 class ConfigFile(HyperBaseMode):
@@ -145,7 +145,7 @@ class ConfigFile(HyperBaseMode):
         return self
 
     @property
-    def keystone_config(self) -> Optional[tuple[str, str]]:
+    def keystone_config(self) -> tuple[str, str] | None:
         for file in self.files:
             if file.keystone:
                 return file.file_glob, file.search_format_pattern
@@ -159,7 +159,7 @@ class ConfigVersionUpdater:
         project_root: Path,
         full_document: TOMLDocument,
         config_table: TOMLDocument,
-        newline: Optional[str],
+        newline: str | None,
     ) -> None:
         """
         Initialize instance.
@@ -201,10 +201,10 @@ class ConfigVersionUpdater:
         return tomlkit.dumps(self._full_document)
 
 
-ConfigReadResult: TypeAlias = tuple[ConfigFile, Optional[ConfigVersionUpdater]]
+ConfigReadResult: TypeAlias = tuple[ConfigFile, ConfigVersionUpdater | None]
 
 
-def read_config(config_file: Optional[Path], project_root: Path) -> ConfigReadResult:
+def read_config(config_file: Path | None, project_root: Path) -> ConfigReadResult:
     """
     Read the appropriate configuration file.
 

--- a/hyper_bump_it/_hyper_bump_it/config/keystone_parser.py
+++ b/hyper_bump_it/_hyper_bump_it/config/keystone_parser.py
@@ -5,7 +5,6 @@ version from a keystone file.
 
 from pathlib import Path
 from re import Match
-from typing import Optional
 
 from ..error import IncompleteKeystoneVersionError, VersionNotFound
 from ..format_pattern import create_matching_pattern, keys
@@ -36,7 +35,7 @@ def find_current_version(
     raise VersionNotFound(file, search_pattern)
 
 
-def _version_string_from_match(match: Match[str]) -> Optional[str]:
+def _version_string_from_match(match: Match[str]) -> str | None:
     # Work through the matched groups to rebuild the version data.
     # Prefer general keys to explicit current keys.
     # Ignore explicit new and extra keys
@@ -64,7 +63,7 @@ def _version_string_from_match(match: Match[str]) -> Optional[str]:
     return _build_version(values)
 
 
-def _build_version(values: dict[str, str]) -> Optional[str]:
+def _build_version(values: dict[str, str]) -> str | None:
     try:
         version_string = "{major}.{minor}.{patch}".format(
             major=values["major"],
@@ -75,7 +74,7 @@ def _build_version(values: dict[str, str]) -> Optional[str]:
         return None
 
     if "prerelease" in values:
-        version_string = f'{version_string}-{values["prerelease"]}'
+        version_string = f"{version_string}-{values['prerelease']}"
     if "build" in values:
-        version_string = f'{version_string}+{values["build"]}'
+        version_string = f"{version_string}+{values['build']}"
     return version_string

--- a/hyper_bump_it/_hyper_bump_it/core.py
+++ b/hyper_bump_it/_hyper_bump_it/core.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from git import Repo
 
 from . import execution_plan, files, ui, vcs
@@ -55,8 +53,8 @@ def _construct_plan(
     new_version: Version,
     planned_changes: list[PlannedChange],
     git_operations_info: GitOperationsInfo,
-    repo: Optional[Repo],
-    config_version_updater: Optional[ConfigVersionUpdater],
+    repo: Repo | None,
+    config_version_updater: ConfigVersionUpdater | None,
 ) -> execution_plan.ExecutionPlan:
     plan = execution_plan.ExecutionPlan()
     git_actions: list[execution_plan.Action] = []
@@ -77,7 +75,7 @@ def _construct_plan(
 def _construct_patch_plan(
     new_version: Version,
     planned_changes: list[PlannedChange],
-    config_version_updater: Optional[ConfigVersionUpdater],
+    config_version_updater: ConfigVersionUpdater | None,
 ) -> execution_plan.ExecutionPlan:
     plan = execution_plan.ExecutionPlan()
     if config_version_updater is not None:

--- a/hyper_bump_it/_hyper_bump_it/error.py
+++ b/hyper_bump_it/_hyper_bump_it/error.py
@@ -2,8 +2,9 @@
 Errors raised by the library.
 """
 
+from collections.abc import Callable, Collection
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Collection, Literal, TypeVar, Union
+from typing import TYPE_CHECKING, Literal, TypeVar
 
 from pydantic import ValidationError
 from rich.text import Text
@@ -347,7 +348,7 @@ class DisallowedInitialBranchError(GitError):
 class AlreadyExistsError(GitError):
     def __init__(
         self,
-        ref_type: Union[Literal["branch"], Literal["tag"]],
+        ref_type: Literal["branch"] | Literal["tag"],
         name: str,
         project_root: Path,
     ) -> None:
@@ -397,9 +398,7 @@ class ConfigurationAlreadyExistsError(ConfigurationError):
 
 
 class ConfigurationFileError(ConfigurationError):
-    def __init__(
-        self, file: Path, message_suffix: Union[str, Callable[[], str]]
-    ) -> None:
+    def __init__(self, file: Path, message_suffix: str | Callable[[], str]) -> None:
         self.file = file
         if not isinstance(message_suffix, str):
             message_suffix = message_suffix()

--- a/hyper_bump_it/_hyper_bump_it/execution_plan.py
+++ b/hyper_bump_it/_hyper_bump_it/execution_plan.py
@@ -5,7 +5,7 @@ The plan is created before performing any operations so that the user can confir
 to be made before files are edited.
 """
 
-from typing import Optional, Protocol, TypeVar
+from typing import Protocol, TypeVar
 
 from git import Repo
 from rich.text import Text
@@ -236,7 +236,7 @@ def git_actions(
 ) -> tuple[list[Action], list[Action]]:
     initial_actions: list[Action] = []
     final_actions: list[Action] = []
-    switch_back: Optional[Action] = None
+    switch_back: Action | None = None
     if git_operations_info.actions.branch.should_create:
         initial_actions.append(
             CreateBranchAction(repo, git_operations_info.branch_name)

--- a/hyper_bump_it/_hyper_bump_it/format_pattern/matching_pattern.py
+++ b/hyper_bump_it/_hyper_bump_it/format_pattern/matching_pattern.py
@@ -5,7 +5,6 @@ Convert a search pattern into a regex pattern.
 import re
 from re import Pattern
 from string import Formatter, Template
-from typing import Optional
 
 from ..error import FormatKeyError, FormatPatternError, TodayFormatKeyError
 from . import keys
@@ -108,7 +107,7 @@ class KeystoneFormatter(Formatter):
             raise TodayFormatKeyError(format_spec, _TODAY_REPLACEMENT_REGEX.keys())
         return f"(?P<{keys.TODAY}>{result})"
 
-    def convert_field(self, value: str, conversion: Optional[str]) -> str:
+    def convert_field(self, value: str, conversion: str | None) -> str:
         # don't preform any conversion operations
         return value
 

--- a/hyper_bump_it/_hyper_bump_it/format_pattern/text_formatter.py
+++ b/hyper_bump_it/_hyper_bump_it/format_pattern/text_formatter.py
@@ -5,7 +5,6 @@ Central place for performing text formatting.
 from datetime import date
 from enum import Enum, auto
 from string import Formatter
-from typing import Optional
 
 from ..error import FormatKeyError, FormatPatternError
 from ..version import Version
@@ -22,7 +21,7 @@ class TextFormatter:
         self,
         current_version: Version,
         new_version: Version,
-        today: Optional[date] = None,
+        today: date | None = None,
     ) -> None:
         """
         Initialize an instance.
@@ -35,9 +34,7 @@ class TextFormatter:
         self._new_version = new_version
         self._today = today or date.today()
 
-    def format(
-        self, format_pattern: str, context: Optional[FormatContext] = None
-    ) -> str:
+    def format(self, format_pattern: str, context: FormatContext | None = None) -> str:
         """
         Perform string formatting on the given pattern.
 

--- a/hyper_bump_it/_hyper_bump_it/planned_changes.py
+++ b/hyper_bump_it/_hyper_bump_it/planned_changes.py
@@ -6,7 +6,6 @@ import difflib
 from dataclasses import InitVar, dataclass, field
 from functools import cached_property
 from pathlib import Path
-from typing import Optional
 
 _LINE_FEED = b"\n"[0]
 _CARRIAGE_RETURN = b"\r"[0]
@@ -19,7 +18,7 @@ class PlannedChange:
     relative_file: Path = field(init=False)
     old_content: str
     new_content: str
-    newline: Optional[str]
+    newline: str | None
 
     def __post_init__(self, project_root: Path) -> None:
         self.relative_file = self.file.relative_to(project_root)
@@ -40,7 +39,7 @@ class PlannedChange:
         )
 
     @staticmethod
-    def detect_line_ending(data: bytes) -> Optional[str]:
+    def detect_line_ending(data: bytes) -> str | None:
         """
         Attempt to determine the line ending used within a file.
 

--- a/hyper_bump_it/_hyper_bump_it/ui.py
+++ b/hyper_bump_it/_hyper_bump_it/ui.py
@@ -4,7 +4,7 @@ Display interface for working with rich.
 
 from collections.abc import Iterable, Mapping
 from enum import Enum
-from typing import Optional, TypeAlias, TypeVar, Union, cast, overload
+from typing import TypeAlias, TypeVar, cast, overload
 
 from rich import prompt
 from rich.align import AlignMethod
@@ -18,8 +18,8 @@ from rich.theme import Theme
 
 from .compat import LiteralString
 
-TextType: TypeAlias = Union[Text, LiteralString]
-PanelMessage: TypeAlias = Union[RichCast, str]
+TextType: TypeAlias = Text | LiteralString
+PanelMessage: TypeAlias = RichCast | str
 
 _DISPLAY_THEME = Theme(
     styles={
@@ -53,7 +53,7 @@ def blank_line() -> None:
     _CONSOLE.print()
 
 
-def display(message: Optional[TextType]) -> None:
+def display(message: TextType | None) -> None:
     _CONSOLE.print(message)
 
 
@@ -64,7 +64,7 @@ def rule(message: TextType) -> None:
 def panel(
     message: PanelMessage,
     border_style: StyleType,
-    title: Optional[TextType],
+    title: TextType | None,
     title_align: AlignMethod = "left",
 ) -> None:
     _CONSOLE.print(
@@ -77,10 +77,10 @@ def ask(message: TextType, *, default: str = ...) -> str: ...
 
 
 @overload
-def ask(message: TextType, *, default: None) -> Optional[str]: ...
+def ask(message: TextType, *, default: None) -> str | None: ...
 
 
-def ask(message: TextType, *, default: Optional[str] = None) -> Optional[str]:
+def ask(message: TextType, *, default: str | None = None) -> str | None:
     return prompt.Prompt.ask(
         message, default=default, show_default=False, console=_CONSOLE
     )
@@ -107,16 +107,16 @@ def choice(
 @overload
 def choice(
     message: Text, *, choices: list[str], default: None, show_choices: bool = False
-) -> Optional[str]: ...
+) -> str | None: ...
 
 
 def choice(
     message: Text,
     *,
     choices: list[str],
-    default: Union[Optional[str], _Sentinel] = _NOT_GIVEN,
+    default: str | None | _Sentinel = _NOT_GIVEN,
     show_choices: bool = False,
-) -> Optional[str]:
+) -> str | None:
     if isinstance(default, _Sentinel):
         return prompt.Prompt.ask(
             message,
@@ -193,7 +193,7 @@ def display_diff(diff_text: str) -> None:
 
 def list_options(
     option_descriptions: Mapping[str, TextType],
-    default: Optional[str] = None,
+    default: str | None = None,
 ) -> Text:
     """
     Write the list of options and descriptions to the given text instance.

--- a/hyper_bump_it/_hyper_bump_it/version.py
+++ b/hyper_bump_it/_hyper_bump_it/version.py
@@ -5,7 +5,7 @@ Semantic version parsing and data structure.
 import re
 from dataclasses import dataclass
 from functools import cached_property, total_ordering
-from typing import TypeAlias, Union
+from typing import TypeAlias
 
 # Implementation based on python-semanticverison, which is distributed under two-clause BSD license.
 
@@ -53,7 +53,7 @@ class _Alpha:
         return NotImplemented
 
 
-OrderingValue: TypeAlias = Union[int, _Max, _Numeric, _Alpha]
+OrderingValue: TypeAlias = int | _Max | _Numeric | _Alpha
 
 
 @total_ordering

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,21 +2,15 @@
 requires = ["hatchling==1.28.0"]
 build-backend = "hatchling.build"
 
-
 [project]
 name = "hyper-bump-it"
 version = "0.5.3"
 description = "A version bumping tool"
 readme = "README.md"
+license = {text = "MIT"}
 requires-python = ">=3.10,<4.0"
-license = "MIT"
-dependencies = [
-    "GitPython>=3.1.35,<4",
-    "tomlkit>=0.11.6,<1.0",
-    "typer>=0.9.0,<1.0",
-    "pydantic>=2.1.0,<3",
-    "rich>=12.6.0,<15",
-    "typing-extensions>=4.4.0,<5; python_version < '3.11'",
+authors = [
+    {name = "Patrick Lannigan", email = "p.lannigan@gmail.com"}
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
@@ -32,8 +26,13 @@ keywords = [
     "bump",
     "command line"
 ]
-authors = [
-    {name = "Patrick Lannigan", email = "p.lannigan@gmail.com"}
+dependencies = [
+    "GitPython>=3.1.35,<4",
+    "tomlkit>=0.11.6,<1.0",
+    "typer>=0.9.0,<1.0",
+    "pydantic>=2.1.0,<3",
+    "rich>=12.6.0,<15",
+    "typing-extensions>=4.4.0,<5; python_version < '3.11'",
 ]
 
 [project.urls]
@@ -52,19 +51,17 @@ include = [
 
 # environment management & scripts
 [tool.hatch.envs.default]
+installer = "uv"
 description = "Test and lint the project code"
 dependencies = [
-    "bandit==1.9.3",
-    "black==26.1.0",
     "coverage==7.13.1",
-    "flake8==7.3.0",
-    "isort==7.0.0",
     "mypy==1.19.1",
     "pytest==9.0.2",
     "pytest-cov==7.0.0",
     "pytest-freezer==0.4.9",
     "pytest-mock==3.15.1",
     "pdbpp==0.12.0.post1",
+    "ruff==0.14.14",
 ]
 [tool.hatch.envs.default.scripts]
 test-no-cov = "pytest --no-cov {args}"
@@ -72,34 +69,28 @@ test = "pytest --cov-report html {args}"
 test-ci = "pytest {args}"
 typing = "mypy"
 _fmt = [
-    "black --quiet .",
-    "isort .",
+    "ruff check --fix .",
+    "ruff format .",
 ]
-black-check = "black --check --diff ."
-isort-check = "isort --check-only ."
-flake8-check = "flake8"
-bandit-ci = "bandit --ini .bandit -r ."
-bandit-check = "bandit-ci --quiet"
+ruff-check = "ruff check hyper_bump_it tests"
+ruff-format-check = "ruff format --check hyper_bump_it tests"
 check-strict = [
-    "black-check",
-    "isort-check",
+    "ruff-check",
+    "ruff-format-check",
     "typing",
     "test",
-    "flake8-check",
-    "bandit-check",
 ]
 check = [
     "_fmt",
     "typing",
     "test",
-    "flake8-check",
-    "bandit-check",
 ]
 test-docs-examples = [
     "./docker/validate_docs.sh"
 ]
 
 [tool.hatch.envs.bump]
+installer = "uv"
 description = "Release a new version"
 detached = true
 dependencies = [
@@ -109,6 +100,7 @@ dependencies = [
 it = "hyper-bump-it {args}"
 
 [tool.hatch.envs.docs]
+installer = "uv"
 description = "Generate documentation for the project"
 dependencies = [
     "mike==2.1.3",
@@ -119,7 +111,6 @@ dependencies = [
 [tool.hatch.envs.docs.scripts]
 build = "mkdocs build --strict"
 serve = "mkdocs serve --dev-addr=0.0.0.0:8000"
-
 
 # type checking
 [tool.mypy]
@@ -147,9 +138,8 @@ warn_required_dynamic_aliases = true
 
 # testing
 [tool.pytest.ini_options]
-addopts = "--cov=hyper_bump_it --cov-report xml:/tmp/coverage.xml --cov-report term-missing:skip-covered"
+addopts = "--verbose --cov=hyper_bump_it --cov-report xml:/tmp/coverage.xml --cov-report term-missing"
 testpaths = ["tests"]
-verbosity_assertions = 2
 
 [tool.coverage.run]
 branch = true
@@ -162,13 +152,43 @@ exclude_lines = [
     "pragma: no cover"
 ]
 
-# code formatting
-[tool.black]
+# linting and formatting with ruff
+[tool.ruff]
 line-length = 88
-target-version = ["py310", "py311"]
+target-version = "py310"
 
-[tool.isort]
-profile = "black"
+[tool.ruff.lint]
+select = [
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # pyflakes
+    "I",    # isort
+    "UP",   # pyupgrade
+    "B",    # flake8-bugbear
+    "C4",   # flake8-comprehensions
+    "SIM",  # flake8-simplify
+    "S",    # flake8-bandit (security)
+]
+ignore = [
+    "E501",   # line too long (handled by formatter)
+    "B904",   # raise from err - would require refactoring existing exception handling
+    "SIM102", # nested if - sometimes clearer to keep separate
+    "SIM110", # use any() - sometimes explicit loop is clearer
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = [
+    "S101",  # assert is standard in pytest
+    "B008",  # function calls in defaults - common pattern in test fixtures
+]
+"hyper_bump_it/_hyper_bump_it/cli/init.py" = ["B006"]  # mutable default for CLI args
+
+[tool.ruff.lint.isort]
+known-first-party = ["hyper_bump_it"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
 
 # version bumping
 [tool.hyper-bump-it.git.actions]

--- a/requirements-bootstrap.txt
+++ b/requirements-bootstrap.txt
@@ -1,3 +1,5 @@
 # The project dependencies & environments are managed by hatch.
-# This requirements file can be used to do the initial install of hatch.
+# uv is used as the installer for faster package installation.
+# This requirements file can be used to do the initial install.
 hatch==1.16.3
+uv==0.9.27

--- a/tests/_hyper_bump_it/cli/interactive/test_files.py
+++ b/tests/_hyper_bump_it/cli/interactive/test_files.py
@@ -1,5 +1,5 @@
 from io import StringIO
-from typing import Optional, cast
+from typing import cast
 
 import pytest
 from rich.text import Text
@@ -26,7 +26,7 @@ def create_invalid_first(
 ) -> DefinitionValidator:
     was_called = False
 
-    def _validator(_) -> Optional[ValidationFailure]:
+    def _validator(_) -> ValidationFailure | None:
         nonlocal was_called
         if was_called:
             return None

--- a/tests/_hyper_bump_it/cli/test_init.py
+++ b/tests/_hyper_bump_it/cli/test_init.py
@@ -69,7 +69,7 @@ def test_init__invalid__error(cli_args: list[str], expected_output_regex):
 @pytest.mark.parametrize(
     "args",
     [
-        tuple(),
+        (),
         ("--allowed-init-branch", sd.SOME_ALLOWED_BRANCH),
     ],
 )

--- a/tests/_hyper_bump_it/cli/test_to.py
+++ b/tests/_hyper_bump_it/cli/test_to.py
@@ -207,9 +207,9 @@ def test_to__allowed_init_branch_not_given__not_included_in_args(mocker):
 
     assert_success(result)
     mock_config_for_bump_to.assert_called_once()
-    assert (
-        mock_config_for_bump_to.call_args.args[0].allowed_initial_branches is None
-    ), result.output
+    assert mock_config_for_bump_to.call_args.args[0].allowed_initial_branches is None, (
+        result.output
+    )
 
 
 def test_to__allow_any_branch__other_branches_cleared(mocker):

--- a/tests/_hyper_bump_it/config/test_application.py
+++ b/tests/_hyper_bump_it/config/test_application.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 from textwrap import dedent
-from typing import Optional
 
 import pytest
 import tomlkit
@@ -156,9 +155,11 @@ def test_config_for_bump_to__keystone_version__expected_result(tmp_path: Path):
         sd.some_minimal_config_text(file.ROOT_TABLE_KEY, version=None)
     )
     keystone_file = tmp_path / sd.SOME_GLOB_MATCHED_FILE_NAME
-    keystone_file.write_text(dedent(f"""\
+    keystone_file.write_text(
+        dedent(f"""\
     version: {sd.SOME_VERSION_STRING}
-    """))
+    """)
+    )
 
     config = application.config_for_bump_to(
         sd.no_config_override_bump_to_args(
@@ -182,9 +183,11 @@ def test_config_for_bump_to__cli_overrides__values_from_cli_not_config_fie(
         sd.some_minimal_config_text(file.ROOT_TABLE_KEY, version=None)
     )
     keystone_file = tmp_path / sd.SOME_GLOB_MATCHED_FILE_NAME
-    keystone_file.write_text(dedent(f"""\
+    keystone_file.write_text(
+        dedent(f"""\
     version: {sd.SOME_VERSION_STRING}
-    """))
+    """)
+    )
 
     config = application.config_for_bump_to(
         sd.some_bump_to_args(config_file=config_file, project_root=tmp_path)
@@ -293,9 +296,11 @@ def test_config_for_bump_to__keystone_glob_multi_match__error(tmp_path: Path):
         sd.SOME_OTHER_GLOB_MATCHED_FILE_NAME,
     ):
         keystone_file = tmp_path / keystone_file_name
-        keystone_file.write_text(dedent(f"""\
+        keystone_file.write_text(
+            dedent(f"""\
         version: {sd.SOME_VERSION_STRING}
-        """))
+        """)
+        )
 
     with pytest.raises(KeystoneFileGlobError, match="Matched: "):
         application.config_for_bump_to(
@@ -333,9 +338,11 @@ def test_config_for_bump_by__keystone_version__expected_result(tmp_path: Path):
         sd.some_minimal_config_text(file.ROOT_TABLE_KEY, version=None)
     )
     keystone_file = tmp_path / sd.SOME_GLOB_MATCHED_FILE_NAME
-    keystone_file.write_text(dedent(f"""\
+    keystone_file.write_text(
+        dedent(f"""\
     version: {sd.SOME_VERSION_STRING}
-    """))
+    """)
+    )
 
     config = application.config_for_bump_by(
         sd.no_config_override_bump_by_args(
@@ -360,9 +367,11 @@ def test_config_for_bump_by__cli_overrides__values_from_cli_not_config_fie(
         sd.some_minimal_config_text(file.ROOT_TABLE_KEY, version=None)
     )
     keystone_file = tmp_path / sd.SOME_GLOB_MATCHED_FILE_NAME
-    keystone_file.write_text(dedent(f"""\
+    keystone_file.write_text(
+        dedent(f"""\
     version: {sd.SOME_VERSION_STRING}
-    """))
+    """)
+    )
 
     config = application.config_for_bump_by(
         sd.some_bump_by_args(config_file=config_file, project_root=tmp_path)
@@ -477,9 +486,11 @@ def test_config_for_bump_by__keystone_glob_multi_match__error(tmp_path: Path):
         sd.SOME_OTHER_GLOB_MATCHED_FILE_NAME,
     ):
         keystone_file = tmp_path / keystone_file_name
-        keystone_file.write_text(dedent(f"""\
+        keystone_file.write_text(
+            dedent(f"""\
         version: {sd.SOME_VERSION_STRING}
-        """))
+        """)
+        )
 
     with pytest.raises(KeystoneFileGlobError, match="Matched: "):
         application.config_for_bump_by(
@@ -545,7 +556,7 @@ def test_config_for_bump_by__keystone_glob_multi_match__error(tmp_path: Path):
 def test_config_for_bump_by__allowed_initial_branches__expected_result(
     file_allowed_branches: set[str],
     file_extend_allowed_branches: set[str],
-    cli_allowed_branches: Optional[set[str]],
+    cli_allowed_branches: set[str] | None,
     expected_branches: set[str],
     tmp_path: Path,
 ):

--- a/tests/_hyper_bump_it/config/test_file.py
+++ b/tests/_hyper_bump_it/config/test_file.py
@@ -33,8 +33,9 @@ def _gen_enum_value_parameters() -> list[tuple[dict[str, str], file.GitActions]]
         for key in ("commit", "branch", "tag"):
             if action == GitAction.CreateAndPush and key in ("branch", "tag"):
                 param = (
-                    {"commit": GitAction.CreateAndPush.value, key: action.value}
-                ), file.GitActions(commit=GitAction.CreateAndPush, **{key: action})
+                    ({"commit": GitAction.CreateAndPush.value, key: action.value}),
+                    file.GitActions(commit=GitAction.CreateAndPush, **{key: action}),
+                )
             else:
                 param = (
                     {key: action.value},
@@ -387,9 +388,11 @@ def test_read_pyproject_config__sub_table_missing__error(tmp_path: Path):
 def test_read_pyproject_config__configuration_invalid__error(tmp_path: Path):
     config_file = tmp_path / sd.SOME_CONFIG_FILE_NAME
 
-    config_file.write_text(dedent(f"""\
+    config_file.write_text(
+        dedent(f"""\
         [{PYPROJECT_ROOT_TABLE}]
-"""))
+""")
+    )
 
     with pytest.raises(InvalidConfigurationError):
         file.read_pyproject_config(config_file, sd.SOME_PROJECT_ROOT)
@@ -493,9 +496,11 @@ def test_read_hyper_config__sub_table_missing__error(tmp_path: Path):
 def test_read_hyper_config__configuration_invalid__error(tmp_path: Path):
     config_file = tmp_path / sd.SOME_CONFIG_FILE_NAME
 
-    config_file.write_text(dedent(f"""\
+    config_file.write_text(
+        dedent(f"""\
         [{file.ROOT_TABLE_KEY}]
-"""))
+""")
+    )
 
     with pytest.raises(InvalidConfigurationError):
         file.read_hyper_config(config_file, sd.SOME_PROJECT_ROOT)

--- a/tests/_hyper_bump_it/config/test_keystone_parser.py
+++ b/tests/_hyper_bump_it/config/test_keystone_parser.py
@@ -103,9 +103,9 @@ def test_find_current_version__valid_pattern_match__found(
     file = tmp_path / SOME_FILE
     file.write_text(file_content)
 
-    assert (
-        keystone_parser.find_current_version(file, pattern) == expected_version
-    ), description
+    assert keystone_parser.find_current_version(file, pattern) == expected_version, (
+        description
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/_hyper_bump_it/sample_data.py
+++ b/tests/_hyper_bump_it/sample_data.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
 from textwrap import dedent
-from typing import Optional, Union
 
 from git import Repo
 from tomlkit import TOMLDocument
@@ -207,10 +206,8 @@ def some_git_config_file(
     commit_format_pattern=SOME_COMMIT_PATTERN,
     branch_format_pattern=SOME_BRANCH_PATTERN,
     tag_name_format_pattern=SOME_TAG_NAME_PATTERN,
-    allowed_initial_branches: Union[frozenset[str], set[str]] = SOME_ALLOWED_BRANCHES,
-    extend_allowed_initial_branches: Union[
-        frozenset[str], set[str]
-    ] = SOME_ALLOWED_BRANCHES,
+    allowed_initial_branches: frozenset[str] | set[str] = SOME_ALLOWED_BRANCHES,
+    extend_allowed_initial_branches: frozenset[str] | set[str] = SOME_ALLOWED_BRANCHES,
     actions=some_git_actions_config_file(),
 ) -> GitConfigFile:
     return GitConfigFile(
@@ -287,9 +284,9 @@ SOME_PYPROJECT = False
 
 
 def some_config_file(
-    current_version: Optional[Version] = SOME_VERSION,
+    current_version: Version | None = SOME_VERSION,
     show_confirm_prompt: bool = SOME_SHOW_CONFIRM_PROMPT,
-    files: Union[list[FileDefinition], FileDefinition] = some_file_definition(),
+    files: list[FileDefinition] | FileDefinition = some_file_definition(),
     git: GitConfigFile = some_git_config_file(),
 ) -> ConfigFile:
     if isinstance(files, FileDefinition):
@@ -305,9 +302,9 @@ def some_config_file(
 
 def some_minimal_config_text(
     table_root: str,
-    version: Optional[str],
-    file_glob: Optional[str] = SOME_FILE_GLOB,
-    show_confirm_prompt: Optional[bool] = None,
+    version: str | None,
+    file_glob: str | None = SOME_FILE_GLOB,
+    show_confirm_prompt: bool | None = None,
     trim_empty_lines: bool = False,
     include_empty_tables: bool = True,
     *,
@@ -347,10 +344,10 @@ def some_minimal_config_text(
 def no_config_override_bump_to_args(
     project_root: Path,
     new_version: Version = SOME_OTHER_VERSION,
-    config_file: Optional[Path] = None,
+    config_file: Path | None = None,
     dry_run: bool = False,
     patch: bool = False,
-    skip_confirm_prompt: Optional[bool] = None,
+    skip_confirm_prompt: bool | None = None,
 ) -> BumpToArgs:
     return BumpToArgs(
         new_version=new_version,
@@ -375,19 +372,19 @@ def no_config_override_bump_to_args(
 def some_bump_to_args(
     project_root: Path,
     new_version: Version = SOME_OTHER_VERSION,
-    config_file: Optional[Path] = None,
+    config_file: Path | None = None,
     dry_run: bool = False,
     patch: bool = False,
-    skip_confirm_prompt: Optional[bool] = None,
-    current_version: Optional[Version] = SOME_OTHER_PARTIAL_VERSION,
-    commit: Optional[GitAction] = SOME_COMMIT_ACTION,
-    branch: Optional[GitAction] = SOME_BRANCH_ACTION,
-    tag: Optional[GitAction] = SOME_TAG_ACTION,
-    remote: Optional[str] = SOME_REMOTE,
-    commit_format_pattern: Optional[str] = SOME_COMMIT_PATTERN,
-    branch_format_pattern: Optional[str] = SOME_BRANCH_PATTERN,
-    tag_name_format_pattern: Optional[str] = SOME_TAG_NAME_PATTERN,
-    tag_message_format_pattern: Optional[str] = SOME_TAG_MESSAGE_PATTERN,
+    skip_confirm_prompt: bool | None = None,
+    current_version: Version | None = SOME_OTHER_PARTIAL_VERSION,
+    commit: GitAction | None = SOME_COMMIT_ACTION,
+    branch: GitAction | None = SOME_BRANCH_ACTION,
+    tag: GitAction | None = SOME_TAG_ACTION,
+    remote: str | None = SOME_REMOTE,
+    commit_format_pattern: str | None = SOME_COMMIT_PATTERN,
+    branch_format_pattern: str | None = SOME_BRANCH_PATTERN,
+    tag_name_format_pattern: str | None = SOME_TAG_NAME_PATTERN,
+    tag_message_format_pattern: str | None = SOME_TAG_MESSAGE_PATTERN,
     allowed_initial_branches: frozenset[str] = SOME_ALLOWED_BRANCHES,
 ) -> BumpToArgs:
     return BumpToArgs(
@@ -417,10 +414,10 @@ def some_bump_to_args(
 def no_config_override_bump_by_args(
     project_root: Path,
     part_to_bump: BumpPart = SOME_BUMP_PART,
-    config_file: Optional[Path] = None,
+    config_file: Path | None = None,
     dry_run: bool = False,
     patch: bool = False,
-    skip_confirm_prompt: Optional[bool] = None,
+    skip_confirm_prompt: bool | None = None,
 ) -> BumpByArgs:
     return BumpByArgs(
         part_to_bump=part_to_bump,
@@ -445,22 +442,20 @@ def no_config_override_bump_by_args(
 def some_bump_by_args(
     project_root: Path,
     part_to_bump: BumpPart = SOME_BUMP_PART,
-    config_file: Optional[Path] = None,
+    config_file: Path | None = None,
     dry_run: bool = False,
     patch: bool = False,
-    skip_confirm_prompt: Optional[bool] = None,
-    current_version: Optional[Version] = SOME_OTHER_PARTIAL_VERSION,
-    commit: Optional[GitAction] = SOME_COMMIT_ACTION,
-    branch: Optional[GitAction] = SOME_BRANCH_ACTION,
-    tag: Optional[GitAction] = SOME_TAG_ACTION,
-    remote: Optional[str] = SOME_REMOTE,
-    commit_format_pattern: Optional[str] = SOME_COMMIT_PATTERN,
-    branch_format_pattern: Optional[str] = SOME_BRANCH_PATTERN,
-    tag_name_format_pattern: Optional[str] = SOME_TAG_NAME_PATTERN,
-    tag_message_format_pattern: Optional[str] = SOME_TAG_MESSAGE_PATTERN,
-    allowed_initial_branches: Union[
-        Optional[set[str]], frozenset[str]
-    ] = SOME_ALLOWED_BRANCHES,
+    skip_confirm_prompt: bool | None = None,
+    current_version: Version | None = SOME_OTHER_PARTIAL_VERSION,
+    commit: GitAction | None = SOME_COMMIT_ACTION,
+    branch: GitAction | None = SOME_BRANCH_ACTION,
+    tag: GitAction | None = SOME_TAG_ACTION,
+    remote: str | None = SOME_REMOTE,
+    commit_format_pattern: str | None = SOME_COMMIT_PATTERN,
+    branch_format_pattern: str | None = SOME_BRANCH_PATTERN,
+    tag_name_format_pattern: str | None = SOME_TAG_NAME_PATTERN,
+    tag_message_format_pattern: str | None = SOME_TAG_MESSAGE_PATTERN,
+    allowed_initial_branches: set[str] | None | frozenset[str] = SOME_ALLOWED_BRANCHES,
 ) -> BumpByArgs:
     return BumpByArgs(
         part_to_bump=part_to_bump,
@@ -506,12 +501,12 @@ def some_application_config(
     project_root: Path,
     current_version: Version = SOME_VERSION,
     new_version: Version = SOME_OTHER_VERSION,
-    files: Optional[list[File]] = None,
+    files: list[File] | None = None,
     git: Git = some_git(),
     dry_run: bool = False,
     patch: bool = False,
     show_confirm_prompt: bool = True,
-    config_version_updater: Optional[ConfigVersionUpdater] = AnyConfigVersionUpdater(),
+    config_version_updater: ConfigVersionUpdater | None = AnyConfigVersionUpdater(),
 ) -> Config:
     if files is None:
         files = [some_file()]
@@ -533,7 +528,7 @@ def some_planned_change(
     project_root=SOME_ABSOLUTE_DIRECTORY,
     old_content=SOME_FILE_CONTENT,
     new_content=SOME_OTHER_FILE_CONTENT,
-    newline: Optional[str] = "\n",
+    newline: str | None = "\n",
 ) -> PlannedChange:
     return PlannedChange(
         file=file,
@@ -554,9 +549,9 @@ class InitedRepo:
 
 def some_git_repo(
     test_root: Path,
-    remote: Optional[str] = None,
-    branch: Optional[str] = None,
-    tag_name: Optional[str] = None,
+    remote: str | None = None,
+    branch: str | None = None,
+    tag_name: str | None = None,
     tag_message: str = SOME_TAG_MESSAGE,
     detached: bool = False,
     sign_commits: bool = False,

--- a/tests/_hyper_bump_it/test_execution_plan.py
+++ b/tests/_hyper_bump_it/test_execution_plan.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from io import StringIO
 from itertools import zip_longest
-from typing import Type
 
 import pytest
 
@@ -744,8 +743,8 @@ def test_push_changes__display_needs_escaping__show_description(
 )
 def test_git_actions__some_git_actions__expected_action_lists(
     actions,
-    expected_initial_actions: list[Type],
-    expected_final_actions: list[Type],
+    expected_initial_actions: list[type],
+    expected_final_actions: list[type],
     mocker,
 ):
     initial_actions, final_actions = execution_plan.git_actions(

--- a/tests/_hyper_bump_it/test_files.py
+++ b/tests/_hyper_bump_it/test_files.py
@@ -1,7 +1,6 @@
 import os
 from pathlib import Path
 from textwrap import dedent
-from typing import Optional
 
 import pytest
 from freezegun.api import FrozenDateTimeFactory
@@ -226,7 +225,7 @@ def test_collect_planned_changes__multiline_search_replace__planned_change_with_
     ],
 )
 def test_collect_planned_changes__detect_line_ending__expected_ending(
-    text: str, expected_line_ending: Optional[str], tmp_path: Path
+    text: str, expected_line_ending: str | None, tmp_path: Path
 ):
     some_file = tmp_path / SOME_FILE_NAME
     some_file.write_bytes(text.encode())
@@ -346,7 +345,7 @@ def test_collect_planned_changes__no_files_matched__error(tmp_path: Path):
     ],
 )
 def test_perform_change__file_updated_proper_end(
-    newline: Optional[str], expected_newline: str, tmp_path: Path
+    newline: str | None, expected_newline: str, tmp_path: Path
 ):
     original_text = f"--{sd.SOME_VERSION}--\n"
     replacement_text = f"--{sd.SOME_OTHER_VERSION}--\n"

--- a/tests/_hyper_bump_it/test_ui.py
+++ b/tests/_hyper_bump_it/test_ui.py
@@ -24,7 +24,7 @@ SOME_NON_OPTION_VALUE = "not an option value"
 def test_blank_line__newline(capture_rich: StringIO):
     ui.blank_line()
 
-    assert "\n" == capture_rich.getvalue()
+    assert capture_rich.getvalue() == "\n"
 
 
 def test_enum_prompt__no_response__default(force_input: ForceInput):


### PR DESCRIPTION
## Summary
- Replace black, isort, flake8, and bandit with ruff for linting and formatting
- Configure hatch to use uv as the package installer for faster dependency installation
- Update CI workflow to use a single ruff job instead of separate linting tools
- Update docker/devbox.dockerfile to install uv system-wide
- Remove .flake8 and .bandit config files (rules now consolidated in pyproject.toml via ruff)